### PR TITLE
⚡ perf(home-entry-scene): offload Come In zoom to compositor and rasterize SVGs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ test-results
 
 demos/
 .generated
+# Local Pi runtime state
+.atl/

--- a/apps/web/src/lib/features/home-entry-scene/canvas/svg-bitmap.svelte.spec.ts
+++ b/apps/web/src/lib/features/home-entry-scene/canvas/svg-bitmap.svelte.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { rasterizeSvgUrl } from './svg-bitmap';
+
+const svgDataUrl = (markup: string) => `data:image/svg+xml,${encodeURIComponent(markup)}`;
+
+const loadImage = (url: string) =>
+	new Promise<HTMLImageElement>((resolve, reject) => {
+		const image = new Image();
+		image.onload = () => resolve(image);
+		image.onerror = () => reject(new Error(`failed to load ${url}`));
+		image.src = url;
+	});
+
+const samplePixel = (image: HTMLImageElement, x: number, y: number) => {
+	const canvas = document.createElement('canvas');
+	canvas.width = image.naturalWidth;
+	canvas.height = image.naturalHeight;
+	const context = canvas.getContext('2d');
+	if (!context) throw new Error('no 2d context');
+	context.drawImage(image, 0, 0);
+	return [...context.getImageData(x, y, 1, 1).data];
+};
+
+describe('rasterizeSvgUrl', () => {
+	it('turns an svg data url into a fixed-resolution bitmap so browsers never re-rasterize it', async () => {
+		const url = await rasterizeSvgUrl(
+			svgDataUrl(
+				'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10"><rect width="10" height="10" fill="#ff0000"/></svg>'
+			),
+			{ width: 64, height: 64 }
+		);
+
+		expect(url).not.toContain('svg');
+
+		const image = await loadImage(url);
+		expect(image.naturalWidth).toBe(64);
+		expect(image.naturalHeight).toBe(64);
+		expect(samplePixel(image, 32, 32)).toEqual([255, 0, 0, 255]);
+	});
+
+	it('rasterizes svgs that only declare a viewBox, like the graffiti logo asset', async () => {
+		const url = await rasterizeSvgUrl(
+			svgDataUrl(
+				'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 10"><rect width="20" height="10" fill="#00ff00"/></svg>'
+			),
+			{ width: 80, height: 40 }
+		);
+
+		const image = await loadImage(url);
+		expect(image.naturalWidth).toBe(80);
+		expect(image.naturalHeight).toBe(40);
+		expect(samplePixel(image, 40, 20)).toEqual([0, 255, 0, 255]);
+	});
+
+	it('reuses the cached bitmap for repeated requests of the same artwork', async () => {
+		const source = svgDataUrl(
+			'<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><rect width="8" height="8" fill="#0000ff"/></svg>'
+		);
+
+		const [first, second] = await Promise.all([
+			rasterizeSvgUrl(source, { width: 32, height: 32 }),
+			rasterizeSvgUrl(source, { width: 32, height: 32 })
+		]);
+
+		expect(first).toBe(second);
+		expect(await rasterizeSvgUrl(source, { width: 32, height: 32 })).toBe(first);
+	});
+});

--- a/apps/web/src/lib/features/home-entry-scene/canvas/svg-bitmap.ts
+++ b/apps/web/src/lib/features/home-entry-scene/canvas/svg-bitmap.ts
@@ -1,0 +1,109 @@
+export type SvgRasterSize = {
+	height: number;
+	width: number;
+};
+
+/*
+ * Firefox rasterizes SVG images on the content main thread at their effective
+ * on-screen resolution. While the museum wall zooms (scale ~18x) that meant
+ * redrawing the brick/frame/logo vectors at 7000px+ per frame — 100ms+ jank.
+ * Rasterizing once into a fixed-size bitmap turns them into plain textures
+ * that the compositor merely samples.
+ */
+const bitmapCache = new Map<string, Promise<string>>();
+
+const SVG_DATA_URL_PREFIX = 'data:image/svg+xml,';
+
+const loadSvgMarkup = async (svgUrl: string) => {
+	if (svgUrl.startsWith(SVG_DATA_URL_PREFIX)) {
+		return decodeURIComponent(svgUrl.slice(SVG_DATA_URL_PREFIX.length));
+	}
+
+	const response = await fetch(svgUrl);
+	if (!response.ok) {
+		throw new Error(`failed to fetch svg: ${svgUrl}`);
+	}
+
+	return response.text();
+};
+
+/*
+ * drawImage rasterizes dimensionless SVGs (viewBox only) at a fallback size,
+ * so the raster size is pinned on the root element before decoding instead.
+ */
+const sizeSvgMarkup = (markup: string, size: SvgRasterSize) => {
+	const svgDocument = new DOMParser().parseFromString(markup, 'image/svg+xml');
+	const root = svgDocument.documentElement;
+
+	if (root.tagName !== 'svg') {
+		throw new Error('source is not an svg document');
+	}
+
+	root.setAttribute('width', `${size.width}`);
+	root.setAttribute('height', `${size.height}`);
+
+	return new XMLSerializer().serializeToString(root);
+};
+
+const decodeSvgImage = async (markup: string) => {
+	const svgBlob = new Blob([markup], { type: 'image/svg+xml' });
+	const svgObjectUrl = URL.createObjectURL(svgBlob);
+
+	try {
+		const image = new Image();
+		image.src = svgObjectUrl;
+		await image.decode();
+		return image;
+	} finally {
+		// Safe to revoke after decode: the pixels already live in the image.
+		URL.revokeObjectURL(svgObjectUrl);
+	}
+};
+
+const rasterize = async (svgUrl: string, size: SvgRasterSize) => {
+	const width = Math.max(1, Math.round(size.width));
+	const height = Math.max(1, Math.round(size.height));
+	const markup = sizeSvgMarkup(await loadSvgMarkup(svgUrl), { height, width });
+	const image = await decodeSvgImage(markup);
+
+	const canvas = document.createElement('canvas');
+	canvas.width = width;
+	canvas.height = height;
+	const context = canvas.getContext('2d');
+	if (!context) {
+		throw new Error('2d canvas context unavailable');
+	}
+
+	context.drawImage(image, 0, 0, width, height);
+
+	const bitmapBlob = await new Promise<Blob>((resolve, reject) => {
+		canvas.toBlob(
+			(blob) => (blob ? resolve(blob) : reject(new Error('canvas.toBlob returned null'))),
+			'image/png'
+		);
+	});
+
+	return URL.createObjectURL(bitmapBlob);
+};
+
+/**
+ * Rasterizes an SVG (data URL or fetchable URL) into a PNG blob URL of the
+ * requested pixel size. Results are cached per source and size for the
+ * lifetime of the page.
+ */
+export const rasterizeSvgUrl = (svgUrl: string, size: SvgRasterSize) => {
+	const key = `${Math.round(size.width)}x${Math.round(size.height)}:${svgUrl}`;
+	const cached = bitmapCache.get(key);
+	if (cached) {
+		return cached;
+	}
+
+	const pending = rasterize(svgUrl, size).catch((error) => {
+		// Drop failed attempts so a later call can retry.
+		bitmapCache.delete(key);
+		throw error;
+	});
+
+	bitmapCache.set(key, pending);
+	return pending;
+};

--- a/apps/web/src/lib/features/home-entry-scene/components/MuseumWallOverlay.svelte
+++ b/apps/web/src/lib/features/home-entry-scene/components/MuseumWallOverlay.svelte
@@ -5,6 +5,12 @@
 	import GameButton from '$lib/features/shared-ui/components/GameButton.svelte';
 	import graffitiLogoUrl from '$lib/assets/logo-graffiti.svg';
 	import { applyMuseumWallWillChange } from '$lib/features/home-entry-scene/components/museum-wall-will-change';
+	import {
+		playWallZoomIn,
+		playWallZoomOut,
+		resetWallZoom,
+		type WallZoomGeometry
+	} from '$lib/features/home-entry-scene/components/museum-wall-zoom';
 	import { waitForPageLayoutReady } from '$lib/features/home-entry-scene/components/page-layout-ready';
 	import MuseumWindowFrame from '$lib/features/home-entry-scene/components/MuseumWindowFrame.svelte';
 	import {
@@ -12,6 +18,7 @@
 		museumWindowAspectRatio,
 		museumWindowOpening
 	} from '$lib/features/home-entry-scene/canvas/museum-canvas';
+	import { rasterizeSvgUrl } from '$lib/features/home-entry-scene/canvas/svg-bitmap';
 	import type {
 		EntryFlowEvent,
 		EntryFlowState
@@ -58,11 +65,15 @@
 	let frameVisualElement = $state<HTMLDivElement | null>(null);
 	let frameElement = $state<HTMLDivElement | null>(null);
 	let openingElement = $state<HTMLDivElement | null>(null);
-	let targetScale = $state(1);
-	let finalScale = $state(1);
-	let translateX = $state(0);
-	let translateY = $state(0);
-	const wallPatternUrl = createMuseumWallPatternUrl();
+	const zoomGeometry: WallZoomGeometry = { finalScale: 1, translateX: 0, translateY: 0 };
+	// SVG sources render the first frame; bitmaps replace them after mount so
+	// the zoom never triggers main-thread SVG re-rasterization (see svg-bitmap).
+	const WALL_TILE_CSS_PX = 512;
+	const LOGO_MAX_WIDTH_CSS_PX = 544; // clamp(24rem, 36vw, 34rem) upper bound
+	const LOGO_VIEWBOX_RATIO = 440 / 680;
+	const wallPatternSvgUrl = createMuseumWallPatternUrl();
+	let wallPatternUrl = $state(wallPatternSvgUrl);
+	let logoUrl = $state(graffitiLogoUrl);
 	let wallOpeningBounds = $state({
 		bottom: OPENING_BOTTOM_CSS,
 		left: OPENING_LEFT_CSS,
@@ -70,11 +81,9 @@
 		top: OPENING_TOP_CSS
 	});
 
-	let forwardTimeline: gsap.core.Timeline | null = null;
-	let reverseTimeline: gsap.core.Timeline | null = null;
 	let enterFallbackHandle: ReturnType<typeof setTimeout> | null = null;
 	let resetFallbackHandle: ReturnType<typeof setTimeout> | null = null;
-	let rebuildPending = false;
+	let measurePending = false;
 
 	const clampUnit = (value: number) => Math.min(1, Math.max(0, value));
 	const toPercent = (value: number) => `${clampUnit(value) * 100}%`;
@@ -94,27 +103,28 @@
 		}
 	};
 
+	const wallElements = () =>
+		overlayElement && wallSceneElement && wallTextureElement && frameVisualElement
+			? { frameVisualElement, overlayElement, wallSceneElement, wallTextureElement }
+			: null;
+
 	const updateWillChange = (active: boolean) => {
-		if (!overlayElement || !wallSceneElement || !wallTextureElement || !frameVisualElement) {
+		const elements = wallElements();
+		if (!elements) {
 			return;
 		}
 
-		applyMuseumWallWillChange(
-			{ frameVisualElement, overlayElement, wallSceneElement, wallTextureElement },
-			active
-		);
+		applyMuseumWallWillChange(elements, active);
 	};
 
 	const resetWallStyles = () => {
-		if (!overlayElement || !wallSceneElement || !wallTextureElement || !frameVisualElement) {
+		const elements = wallElements();
+		if (!elements) {
 			return;
 		}
 
-		gsap.set(overlayElement, { clearProps: 'opacity' });
-		gsap.set(wallSceneElement, { clearProps: 'transform' });
-		gsap.set(wallTextureElement, { clearProps: 'opacity' });
-		gsap.set(frameVisualElement, { clearProps: 'opacity,filter' });
-		updateWillChange(false);
+		resetWallZoom(elements);
+		applyMuseumWallWillChange(elements, false);
 	};
 
 	const updateMeasurements = () => {
@@ -131,7 +141,7 @@
 			measuredOpening.height * GLASS_FOCUS_BOUNDS.height
 		);
 
-		targetScale = Math.max(
+		const targetScale = Math.max(
 			(window.innerWidth + WINDOW_MARGIN * 2) / focusRect.width,
 			(window.innerHeight + WINDOW_MARGIN * 2) / focusRect.height
 		);
@@ -153,210 +163,84 @@
 			)
 		};
 
-		finalScale = targetScale * FINAL_ZOOM_MULTIPLIER;
-		translateX = window.innerWidth / 2 - (focusRect.left + focusRect.width / 2);
-		translateY = window.innerHeight / 2 - (focusRect.top + focusRect.height / 2);
+		zoomGeometry.finalScale = targetScale * FINAL_ZOOM_MULTIPLIER;
+		zoomGeometry.translateX = window.innerWidth / 2 - (focusRect.left + focusRect.width / 2);
+		zoomGeometry.translateY = window.innerHeight / 2 - (focusRect.top + focusRect.height / 2);
 	};
 
-	const createForwardTimeline = () => {
-		if (
-			!overlayElement ||
-			!wallSceneElement ||
-			!wallTextureElement ||
-			!frameVisualElement ||
-			!authOverlayElement
-		) {
-			return null;
-		}
-
-		return gsap
-			.timeline({
-				paused: true,
-				onStart: () => {
-					updateWillChange(true);
-					gsap.set(overlayElement, { opacity: 1 });
-					gsap.set(wallTextureElement, { opacity: 1 });
-					gsap.set(frameVisualElement, { opacity: 1, filter: 'blur(0px)' });
-					gsap.set(authOverlayElement, { opacity: 0, scale: 0.95 });
-					gsap.set(wallSceneElement, { x: 0, y: 0, scale: 1, yPercent: 0 });
-				},
-				onComplete: () => {
-					updateWillChange(false);
-				}
-			})
-			.to(
-				wallSceneElement,
-				{
-					scale: finalScale,
-					x: translateX,
-					y: translateY,
-					duration: ENTER_DURATION,
-					ease: 'power4.in'
-				},
-				0
-			)
-			.to(
-				wallTextureElement,
-				{
-					opacity: 0,
-					duration: 0.26,
-					ease: 'power3.in'
-				},
-				1.52
-			)
-			.to(
-				frameVisualElement,
-				{
-					opacity: 0,
-					filter: 'blur(18px) brightness(1.18)',
-					duration: 0.1,
-					ease: 'power4.in'
-				},
-				1.99
-			)
-			.call(
-				() => {
-					dispatch('TRANSITION_DONE');
-				},
-				undefined,
-				ENTER_DURATION
-			);
-	};
-
-	const createReverseTimeline = () => {
-		if (
-			!overlayElement ||
-			!wallSceneElement ||
-			!wallTextureElement ||
-			!frameVisualElement ||
-			!authOverlayElement
-		) {
-			return null;
-		}
-
-		return gsap
-			.timeline({
-				paused: true,
-				onStart: () => {
-					updateWillChange(true);
-					gsap.set(overlayElement, { opacity: 0 });
-					gsap.set(wallTextureElement, { opacity: 0 });
-					gsap.set(frameVisualElement, { opacity: 0, filter: 'blur(18px) brightness(1.18)' });
-					gsap.set(authOverlayElement, { opacity: 1, scale: 1 });
-					gsap.set(wallSceneElement, {
-						scale: finalScale,
-						x: translateX,
-						y: translateY,
-						yPercent: 0
-					});
-				},
-				onComplete: () => {
-					resetWallStyles();
-					dispatch('TRANSITION_RESET_DONE');
-				}
-			})
-			.to(
-				overlayElement,
-				{
-					opacity: 1,
-					duration: 0.38,
-					ease: 'power2.out'
-				},
-				0
-			)
-			.to(
-				authOverlayElement,
-				{
-					opacity: 0,
-					scale: 0.95,
-					duration: 0.3,
-					ease: 'power1.in'
-				},
-				0
-			)
-			.to(
-				frameVisualElement,
-				{
-					opacity: 1,
-					filter: 'blur(0px) brightness(1)',
-					duration: 0.26,
-					ease: 'power1.out'
-				},
-				0.3
-			)
-			.to(
-				wallTextureElement,
-				{
-					opacity: 1,
-					duration: 0.38,
-					ease: 'power2.in'
-				},
-				0.3
-			)
-			.to(
-				wallSceneElement,
-				{
-					scale: 1,
-					x: 0,
-					y: 0,
-					duration: RESET_DURATION,
-					ease: 'power3.out'
-				},
-				0
-			);
-	};
-
-	const rebuildTimelines = () => {
-		forwardTimeline?.kill();
-		reverseTimeline?.kill();
-
-		updateMeasurements();
-		forwardTimeline = createForwardTimeline();
-		reverseTimeline = createReverseTimeline();
-	};
-
-	const scheduleTimelineRebuild = async () => {
-		if (rebuildPending || typeof window === 'undefined' || typeof document === 'undefined') {
+	const scheduleMeasurement = async () => {
+		if (measurePending || typeof window === 'undefined' || typeof document === 'undefined') {
 			return;
 		}
 
-		rebuildPending = true;
+		measurePending = true;
 		await waitForPageLayoutReady({ document, window });
-		rebuildPending = false;
-		rebuildTimelines();
+		measurePending = false;
+		updateMeasurements();
 	};
 
 	onMount(() => {
 		const handleResize = () => {
-			void scheduleTimelineRebuild();
+			void scheduleMeasurement();
 		};
 
-		void scheduleTimelineRebuild();
+		void scheduleMeasurement();
+
+		const rasterScale = Math.min(window.devicePixelRatio || 1, 2);
+		void rasterizeSvgUrl(wallPatternSvgUrl, {
+			height: WALL_TILE_CSS_PX * rasterScale,
+			width: WALL_TILE_CSS_PX * rasterScale
+		})
+			.then((url) => {
+				wallPatternUrl = url;
+			})
+			.catch(() => {
+				// Keep the SVG source if rasterization fails.
+			});
+		void rasterizeSvgUrl(graffitiLogoUrl, {
+			height: LOGO_MAX_WIDTH_CSS_PX * rasterScale * LOGO_VIEWBOX_RATIO,
+			width: LOGO_MAX_WIDTH_CSS_PX * rasterScale
+		})
+			.then((url) => {
+				logoUrl = url;
+			})
+			.catch(() => {
+				// Keep the SVG source if rasterization fails.
+			});
 
 		window.addEventListener('resize', handleResize);
 
 		return () => {
 			window.removeEventListener('resize', handleResize);
-			forwardTimeline?.kill();
-			reverseTimeline?.kill();
 			clearFallbacks();
 		};
 	});
 
 	$effect(() => {
-		if (authOverlayElement && !forwardTimeline && !reverseTimeline) {
-			void scheduleTimelineRebuild();
-		}
-	});
-
-	$effect(() => {
 		if (entryState === 'transitioning-in') {
 			clearFallbacks();
-			if (!forwardTimeline) {
-				rebuildTimelines();
+			const elements = wallElements();
+
+			if (elements) {
+				// The wall is untransformed while outside, so this measurement is fresh.
+				updateMeasurements();
+				applyMuseumWallWillChange(elements, true);
+
+				if (authOverlayElement) {
+					gsap.set(authOverlayElement, { opacity: 0, scale: 0.95 });
+				}
+
+				const zoom = playWallZoomIn(elements, zoomGeometry);
+				zoom.finished
+					.then(() => {
+						updateWillChange(false);
+						dispatch('TRANSITION_DONE');
+					})
+					.catch(() => {
+						// Cancelled by a newer state change; that path owns cleanup.
+					});
 			}
-			reverseTimeline?.pause(0);
-			forwardTimeline?.restart();
+
 			enterFallbackHandle = setTimeout(
 				() => {
 					if (entryState === 'transitioning-in') {
@@ -369,11 +253,31 @@
 
 		if (entryState === 'transitioning-out') {
 			clearFallbacks();
-			if (!reverseTimeline) {
-				rebuildTimelines();
+			const elements = wallElements();
+
+			if (elements) {
+				applyMuseumWallWillChange(elements, true);
+
+				if (authOverlayElement) {
+					gsap.to(authOverlayElement, {
+						opacity: 0,
+						scale: 0.95,
+						duration: 0.3,
+						ease: 'power1.in'
+					});
+				}
+
+				const zoom = playWallZoomOut(elements, zoomGeometry);
+				zoom.finished
+					.then(() => {
+						resetWallStyles();
+						dispatch('TRANSITION_RESET_DONE');
+					})
+					.catch(() => {
+						// Cancelled by a newer state change; that path owns cleanup.
+					});
 			}
-			forwardTimeline?.pause(0);
-			reverseTimeline?.restart();
+
 			resetFallbackHandle = setTimeout(
 				() => {
 					if (entryState === 'transitioning-out') {
@@ -386,8 +290,6 @@
 
 		if (entryState === 'outside') {
 			clearFallbacks();
-			forwardTimeline?.pause(0);
-			reverseTimeline?.pause(0);
 			resetWallStyles();
 		}
 
@@ -407,7 +309,11 @@
 		bind:this={overlayElement}
 		class="pointer-events-none absolute inset-0 z-[20] overflow-hidden"
 	>
-		<div bind:this={wallSceneElement} class="absolute inset-0 origin-center">
+		<div
+			bind:this={wallSceneElement}
+			data-testid="museum-wall-scene"
+			class="absolute inset-0 origin-center"
+		>
 			<!-- Wall texture rebuilt as two L-shaped slabs instead of a fullscreen mask. -->
 			<div bind:this={wallTextureElement} class="absolute inset-0">
 				<div
@@ -443,7 +349,8 @@
 				<div bind:this={frameVisualElement} class="relative flex items-center justify-center">
 					<!-- Graffiti logo floating beside the frame. -->
 					<img
-						src={graffitiLogoUrl}
+						src={logoUrl}
+						data-testid="museum-wall-logo"
 						alt=""
 						draggable="false"
 						class="pointer-events-none absolute top-[15%] right-[calc(100%-4.5rem)] z-[1] w-[clamp(24rem,36vw,34rem)] -rotate-[10deg] opacity-95"
@@ -468,7 +375,7 @@
 						></div>
 						<!-- Side shadow to separate the frame from the wall. -->
 						<div
-							class="pointer-events-none absolute top-[12%] -left-[8%] h-[88%] w-[92%] bg-[radial-gradient(ellipse_at_88%_12%,rgba(46,28,11,0.18)_0%,rgba(46,28,11,0.28)_36%,rgba(46,28,11,0.14)_58%,transparent_74%)] blur-[14px]"
+							class="pointer-events-none absolute top-[12%] -left-[8%] h-[88%] w-[92%] bg-[radial-gradient(ellipse_at_88%_12%,rgba(46,28,11,0.16)_0%,rgba(46,28,11,0.24)_34%,rgba(46,28,11,0.12)_58%,transparent_82%)]"
 						></div>
 						<div
 							bind:this={openingElement}
@@ -492,7 +399,7 @@
 								class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.025)_48%,rgba(24,14,8,0.06))]"
 							></div>
 							<div
-								class="absolute inset-y-[12%] right-[8%] w-[22%] rounded-full bg-white/6 blur-xl"
+								class="absolute inset-y-[12%] right-[8%] w-[22%] rounded-full bg-[radial-gradient(ellipse_at_center,rgba(255,255,255,0.08)_0%,rgba(255,255,255,0.05)_45%,transparent_72%)]"
 							></div>
 						</div>
 

--- a/apps/web/src/lib/features/home-entry-scene/components/MuseumWallOverlay.svelte.spec.ts
+++ b/apps/web/src/lib/features/home-entry-scene/components/MuseumWallOverlay.svelte.spec.ts
@@ -19,9 +19,10 @@ type MockTimeline = {
 	to: ReturnType<typeof vi.fn>;
 };
 
-const { gsapSet, gsapTimeline, timelineInstances } = vi.hoisted(() => {
+const { gsapSet, gsapTimeline, gsapTo, timelineInstances } = vi.hoisted(() => {
 	const timelineInstances: MockTimeline[] = [];
 	const gsapSet = vi.fn();
+	const gsapTo = vi.fn();
 	const gsapTimeline = vi.fn(() => {
 		const timeline: MockTimeline = {
 			calls: [],
@@ -42,13 +43,14 @@ const { gsapSet, gsapTimeline, timelineInstances } = vi.hoisted(() => {
 		return timeline;
 	});
 
-	return { gsapSet, gsapTimeline, timelineInstances };
+	return { gsapSet, gsapTimeline, gsapTo, timelineInstances };
 });
 
 vi.mock('$lib/client/gsap', () => {
 	const gsap = {
 		set: gsapSet,
-		timeline: gsapTimeline
+		timeline: gsapTimeline,
+		to: gsapTo
 	};
 
 	return {
@@ -56,6 +58,8 @@ vi.mock('$lib/client/gsap', () => {
 		gsap
 	};
 });
+
+const STRUCTURAL_KEYFRAME_KEYS = ['offset', 'computedOffset', 'easing', 'composite'];
 
 const reducedMotionMediaQuery = {
 	addEventListener: vi.fn(),
@@ -73,6 +77,7 @@ describe('MuseumWallOverlay', () => {
 		timelineInstances.length = 0;
 		gsapSet.mockClear();
 		gsapTimeline.mockClear();
+		gsapTo.mockClear();
 		vi.unstubAllGlobals();
 	});
 
@@ -105,12 +110,7 @@ describe('MuseumWallOverlay', () => {
 		authOverlayElement.remove();
 	});
 
-	it('keeps the full Come In timeline when reduced motion is requested', async () => {
-		vi.stubGlobal(
-			'matchMedia',
-			vi.fn(() => reducedMotionMediaQuery)
-		);
-
+	it('swaps wall texture and logo to bitmaps after mount so zooming never re-rasterizes svg', async () => {
 		const authOverlayElement = document.createElement('div');
 		document.body.append(authOverlayElement);
 
@@ -120,17 +120,78 @@ describe('MuseumWallOverlay', () => {
 			entryState: 'outside'
 		});
 
-		await new Promise((resolve) => setTimeout(resolve, 0));
+		const leftSlab = document.querySelector('[data-testid="museum-wall-slab-left"]');
 
-		expect(timelineInstances).toHaveLength(2);
-		expect(
-			timelineInstances.some((timeline) =>
-				timeline.calls.some(
-					(call) =>
-						call.method === 'to' && call.vars?.duration === 2.08 && call.vars?.scale !== undefined
-				)
-			)
-		).toBe(true);
+		await expect
+			.poll(() => leftSlab?.getAttribute('style'), { timeout: 5000 })
+			.toMatch(/background-image:\s*url\(["']?blob:/);
+
+		const logoImage = document.querySelector('[data-testid="museum-wall-logo"]');
+
+		await expect.poll(() => logoImage?.getAttribute('src'), { timeout: 5000 }).toMatch(/^blob:/);
+
+		authOverlayElement.remove();
+	});
+
+	it('runs the come-in zoom on the compositor using only transform and opacity tracks', async () => {
+		const authOverlayElement = document.createElement('div');
+		document.body.append(authOverlayElement);
+
+		const { rerender } = render(MuseumWallOverlay, {
+			authOverlayElement,
+			dispatch: vi.fn(),
+			entryState: 'outside'
+		});
+
+		await rerender({ entryState: 'transitioning-in' });
+
+		const wallScene = document.querySelector('[data-testid="museum-wall-scene"]') as HTMLElement;
+		const zoomAnimations = wallScene.getAnimations();
+
+		expect(zoomAnimations).toHaveLength(1);
+		expect(zoomAnimations[0].effect?.getTiming().duration).toBe(2080);
+
+		const overlayRoot = wallScene.parentElement as HTMLElement;
+		const subtreeAnimations = overlayRoot.getAnimations({ subtree: true });
+
+		expect(subtreeAnimations.length).toBeGreaterThan(1);
+		for (const animation of subtreeAnimations) {
+			const keyframes = (animation.effect as KeyframeEffect).getKeyframes();
+			for (const keyframe of keyframes) {
+				const properties = Object.keys(keyframe).filter(
+					(key) => !STRUCTURAL_KEYFRAME_KEYS.includes(key)
+				);
+				for (const property of properties) {
+					expect(['opacity', 'transform']).toContain(property);
+				}
+			}
+		}
+
+		authOverlayElement.remove();
+	});
+
+	it('keeps the full Come In zoom when reduced motion is requested', async () => {
+		vi.stubGlobal(
+			'matchMedia',
+			vi.fn(() => reducedMotionMediaQuery)
+		);
+
+		const authOverlayElement = document.createElement('div');
+		document.body.append(authOverlayElement);
+
+		const { rerender } = render(MuseumWallOverlay, {
+			authOverlayElement,
+			dispatch: vi.fn(),
+			entryState: 'outside'
+		});
+
+		await rerender({ entryState: 'transitioning-in' });
+
+		const wallScene = document.querySelector('[data-testid="museum-wall-scene"]') as HTMLElement;
+		const zoomAnimations = wallScene.getAnimations();
+
+		expect(zoomAnimations).toHaveLength(1);
+		expect(zoomAnimations[0].effect?.getTiming().duration).toBe(2080);
 
 		authOverlayElement.remove();
 	});

--- a/apps/web/src/lib/features/home-entry-scene/components/MuseumWindowFrame.svelte
+++ b/apps/web/src/lib/features/home-entry-scene/components/MuseumWindowFrame.svelte
@@ -1,10 +1,34 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import {
 		createMuseumWindowFrameUrl,
 		museumWindowAspectRatio
 	} from '$lib/features/home-entry-scene/canvas/museum-canvas';
+	import { rasterizeSvgUrl } from '$lib/features/home-entry-scene/canvas/svg-bitmap';
 
-	const frameUrl = createMuseumWindowFrameUrl();
+	// The frame renders at most 49rem (784px) wide; raster at 2x for sharpness.
+	const FRAME_MAX_WIDTH_CSS_PX = 784;
+	const FRAME_VIEWBOX_RATIO = 640 / 720;
+
+	// The SVG source renders the first (SSR-ready) frame; the bitmap replaces
+	// it after mount so the wall zoom never re-rasterizes the vector art on
+	// the main thread (see svg-bitmap).
+	const frameSvgUrl = createMuseumWindowFrameUrl();
+	let frameUrl = $state(frameSvgUrl);
+
+	onMount(() => {
+		const rasterScale = Math.min(window.devicePixelRatio || 1, 2);
+		void rasterizeSvgUrl(frameSvgUrl, {
+			height: FRAME_MAX_WIDTH_CSS_PX * rasterScale * FRAME_VIEWBOX_RATIO,
+			width: FRAME_MAX_WIDTH_CSS_PX * rasterScale
+		})
+			.then((url) => {
+				frameUrl = url;
+			})
+			.catch(() => {
+				// Keep the SVG source if rasterization fails.
+			});
+	});
 </script>
 
 <img

--- a/apps/web/src/lib/features/home-entry-scene/components/MuseumWindowFrame.svelte.spec.ts
+++ b/apps/web/src/lib/features/home-entry-scene/components/MuseumWindowFrame.svelte.spec.ts
@@ -12,4 +12,12 @@ describe('MuseumWindowFrame', () => {
 		expect(frameImage?.getAttribute('src')).toMatch(/^data:image\/(png|svg\+xml)/);
 		expect(document.querySelector('canvas')).toBeNull();
 	});
+
+	it('swaps the vector frame for a bitmap after mount so zooming never re-rasterizes svg', async () => {
+		render(MuseumWindowFrame);
+
+		const frameImage = document.querySelector('[data-testid="museum-window-frame"]');
+
+		await expect.poll(() => frameImage?.getAttribute('src'), { timeout: 5000 }).toMatch(/^blob:/);
+	});
 });

--- a/apps/web/src/lib/features/home-entry-scene/components/museum-wall-zoom.svelte.spec.ts
+++ b/apps/web/src/lib/features/home-entry-scene/components/museum-wall-zoom.svelte.spec.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	WALL_ZOOM_IN_DURATION_MS,
+	WALL_ZOOM_OUT_DURATION_MS,
+	playWallZoomIn,
+	playWallZoomOut,
+	resetWallZoom,
+	type WallZoomElements
+} from './museum-wall-zoom';
+
+const STRUCTURAL_KEYFRAME_KEYS = ['offset', 'computedOffset', 'easing', 'composite'];
+
+const geometry = { finalScale: 18, translateX: -120, translateY: 64 };
+
+const createElements = (): WallZoomElements => {
+	const overlayElement = document.createElement('div');
+	const wallSceneElement = document.createElement('div');
+	const wallTextureElement = document.createElement('div');
+	const frameVisualElement = document.createElement('div');
+
+	wallSceneElement.append(wallTextureElement, frameVisualElement);
+	overlayElement.append(wallSceneElement);
+	document.body.append(overlayElement);
+
+	return { frameVisualElement, overlayElement, wallSceneElement, wallTextureElement };
+};
+
+const animatedProperties = (animation: Animation) => {
+	const effect = animation.effect as KeyframeEffect;
+
+	return effect
+		.getKeyframes()
+		.flatMap((keyframe) =>
+			Object.keys(keyframe).filter((key) => !STRUCTURAL_KEYFRAME_KEYS.includes(key))
+		);
+};
+
+describe('museum-wall-zoom', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('drives the come-in zoom as a full-length compositor animation', () => {
+		const elements = createElements();
+
+		const zoom = playWallZoomIn(elements, geometry);
+
+		expect(zoom.effect?.getTiming().duration).toBe(WALL_ZOOM_IN_DURATION_MS);
+		expect((zoom.effect as KeyframeEffect).target).toBe(elements.wallSceneElement);
+		expect(animatedProperties(zoom)).toEqual(['transform', 'transform']);
+	});
+
+	it('keeps every come-in track limited to transform and opacity', () => {
+		const elements = createElements();
+
+		playWallZoomIn(elements, geometry);
+
+		const animations = elements.overlayElement.getAnimations({ subtree: true });
+
+		expect(animations.length).toBeGreaterThan(1);
+		for (const animation of animations) {
+			for (const property of animatedProperties(animation)) {
+				expect(['opacity', 'transform']).toContain(property);
+			}
+		}
+	});
+
+	it('drives the close reset back to the wall as a compositor animation', () => {
+		const elements = createElements();
+
+		playWallZoomIn(elements, geometry);
+		const reset = playWallZoomOut(elements, geometry);
+
+		expect(reset.effect?.getTiming().duration).toBe(WALL_ZOOM_OUT_DURATION_MS);
+
+		const keyframes = (reset.effect as KeyframeEffect).getKeyframes();
+		expect(keyframes.at(-1)?.transform).toBe('translate(0px, 0px) scale(1)');
+	});
+
+	it('replaces the previous zoom instead of stacking animations', () => {
+		const elements = createElements();
+
+		const first = playWallZoomIn(elements, geometry);
+		playWallZoomOut(elements, geometry);
+
+		expect(first.playState).toBe('idle');
+		expect(elements.wallSceneElement.getAnimations()).toHaveLength(1);
+	});
+
+	it('resetWallZoom cancels animations and clears inline styles', () => {
+		const elements = createElements();
+
+		const zoom = playWallZoomIn(elements, geometry);
+		resetWallZoom(elements);
+
+		expect(zoom.playState).toBe('idle');
+		expect(elements.overlayElement.getAnimations({ subtree: true })).toHaveLength(0);
+		for (const element of Object.values(elements)) {
+			expect(element.style.opacity).toBe('');
+			expect(element.style.transform).toBe('');
+		}
+	});
+});

--- a/apps/web/src/lib/features/home-entry-scene/components/museum-wall-zoom.ts
+++ b/apps/web/src/lib/features/home-entry-scene/components/museum-wall-zoom.ts
@@ -1,0 +1,107 @@
+export type WallZoomElements = {
+	frameVisualElement: HTMLElement;
+	overlayElement: HTMLElement;
+	wallSceneElement: HTMLElement;
+	wallTextureElement: HTMLElement;
+};
+
+export type WallZoomGeometry = {
+	finalScale: number;
+	translateX: number;
+	translateY: number;
+};
+
+export const WALL_ZOOM_IN_DURATION_MS = 2080;
+export const WALL_ZOOM_OUT_DURATION_MS = 1130;
+
+/*
+ * The zoom runs through the Web Animations API instead of a JS-driven tween so
+ * the compositor keeps animating transform/opacity even while the main thread
+ * is busy (Three.js camera tween, auth overlay mount). Easings are the
+ * cubic-bezier equivalents of the GSAP eases used previously.
+ */
+const EASE_IN_QUINT = 'cubic-bezier(0.64, 0, 0.78, 0)'; // gsap power4.in
+const EASE_IN_QUART = 'cubic-bezier(0.5, 0, 0.75, 0)'; // gsap power3.in
+const EASE_OUT_QUART = 'cubic-bezier(0.25, 1, 0.5, 1)'; // gsap power3.out
+const EASE_OUT_CUBIC = 'cubic-bezier(0.33, 1, 0.68, 1)'; // gsap power2.out
+const EASE_IN_CUBIC = 'cubic-bezier(0.32, 0, 0.67, 0)'; // gsap power2.in
+const EASE_OUT_QUAD = 'cubic-bezier(0.5, 1, 0.89, 1)'; // gsap power1.out
+
+const allElements = (elements: WallZoomElements) => [
+	elements.overlayElement,
+	elements.wallSceneElement,
+	elements.wallTextureElement,
+	elements.frameVisualElement
+];
+
+const wallTransform = ({ finalScale, translateX, translateY }: WallZoomGeometry) =>
+	`translate(${translateX}px, ${translateY}px) scale(${finalScale})`;
+
+const IDENTITY_TRANSFORM = 'translate(0px, 0px) scale(1)';
+
+export const cancelWallZoom = (elements: WallZoomElements) => {
+	for (const element of allElements(elements)) {
+		for (const animation of element.getAnimations()) {
+			animation.cancel();
+		}
+	}
+};
+
+export const resetWallZoom = (elements: WallZoomElements) => {
+	cancelWallZoom(elements);
+
+	for (const element of allElements(elements)) {
+		element.style.removeProperty('opacity');
+		element.style.removeProperty('transform');
+	}
+};
+
+export const playWallZoomIn = (elements: WallZoomElements, geometry: WallZoomGeometry) => {
+	cancelWallZoom(elements);
+	elements.overlayElement.style.opacity = '1';
+
+	elements.wallTextureElement.animate([{ opacity: 1 }, { opacity: 0 }], {
+		delay: 1520,
+		duration: 260,
+		easing: EASE_IN_QUART,
+		fill: 'both'
+	});
+	elements.frameVisualElement.animate([{ opacity: 1 }, { opacity: 0 }], {
+		delay: 1990,
+		duration: 100,
+		easing: EASE_IN_QUINT,
+		fill: 'both'
+	});
+
+	return elements.wallSceneElement.animate(
+		[{ transform: IDENTITY_TRANSFORM }, { transform: wallTransform(geometry) }],
+		{ duration: WALL_ZOOM_IN_DURATION_MS, easing: EASE_IN_QUINT, fill: 'forwards' }
+	);
+};
+
+export const playWallZoomOut = (elements: WallZoomElements, geometry: WallZoomGeometry) => {
+	cancelWallZoom(elements);
+
+	elements.overlayElement.animate([{ opacity: 0 }, { opacity: 1 }], {
+		duration: 380,
+		easing: EASE_OUT_CUBIC,
+		fill: 'both'
+	});
+	elements.frameVisualElement.animate([{ opacity: 0 }, { opacity: 1 }], {
+		delay: 300,
+		duration: 260,
+		easing: EASE_OUT_QUAD,
+		fill: 'both'
+	});
+	elements.wallTextureElement.animate([{ opacity: 0 }, { opacity: 1 }], {
+		delay: 300,
+		duration: 380,
+		easing: EASE_IN_CUBIC,
+		fill: 'both'
+	});
+
+	return elements.wallSceneElement.animate(
+		[{ transform: wallTransform(geometry) }, { transform: IDENTITY_TRANSFORM }],
+		{ duration: WALL_ZOOM_OUT_DURATION_MS, easing: EASE_OUT_QUART, fill: 'forwards' }
+	);
+};

--- a/apps/web/src/lib/features/home-entry-scene/scene/SceneFrameInvalidator.svelte
+++ b/apps/web/src/lib/features/home-entry-scene/scene/SceneFrameInvalidator.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { useThrelte } from '@threlte/core';
+
+	let {
+		onready
+	}: {
+		onready: (invalidate: () => void) => void;
+	} = $props();
+
+	const { invalidate } = useThrelte();
+
+	$effect(() => {
+		onready(invalidate);
+	});
+</script>

--- a/apps/web/src/lib/features/home-entry-scene/scene/StudioScene.svelte
+++ b/apps/web/src/lib/features/home-entry-scene/scene/StudioScene.svelte
@@ -3,11 +3,12 @@
 	import { untrack } from 'svelte';
 	import { gsap } from '$lib/client/gsap';
 	import { Canvas, T } from '@threlte/core';
-	import { GLTF, OrbitControls } from '@threlte/extras';
+	import { GLTF } from '@threlte/extras';
 	import type { Group, Object3D, OrthographicCamera } from 'three';
 	import type { HomeSceneArtworkSlot } from '$lib/features/home-entry-scene/state/home-entry.svelte';
 	import { studioCanvasShadowMap } from '$lib/features/home-entry-scene/scene/studio-renderer-config';
 	import { getStudioDracoLoader } from '$lib/features/home-entry-scene/scene/studio-draco-loader';
+	import SceneFrameInvalidator from '$lib/features/home-entry-scene/scene/SceneFrameInvalidator.svelte';
 	import SceneTextureBindings from '$lib/features/home-entry-scene/scene/SceneTextureBindings.svelte';
 	import StudioLoadingFallback from '$lib/features/shared-3d-world/components/StudioLoadingFallback.svelte';
 	import type { EntryFlowState } from '$lib/features/home-entry-scene/state/entry-state.svelte';
@@ -69,16 +70,7 @@
 				? TOP_CLOSE_CAMERA
 				: DEFAULT_CAMERA;
 
-	let cameraX = $state(initialCamera.cameraX);
-	let cameraZoom = $state(initialCamera.zoom);
-	let cameraHeight = $state(initialCamera.cameraHeight);
-	let cameraDepth = $state(initialCamera.cameraDepth);
-	let cameraTargetX = $state(initialCamera.targetX);
-	let cameraTargetY = $state(initialCamera.targetY);
-	let cameraTargetZ = $state(initialCamera.targetZ);
 	let studioCamera = $state<OrthographicCamera | undefined>(undefined);
-	let modelRotationX = $state(initialCamera.rotationX);
-	let modelRotationY = $state(initialCamera.rotationY);
 	let studioNodes = $state<Record<string, Object3D>>({});
 	let studioSceneRoot = $state<Group | null>(null);
 	let previousScenePose: 'default' | 'left-wall' | 'top-close' | undefined = initialPoseValue;
@@ -108,28 +100,40 @@
 	const sceneReady = $derived(sceneMediaState === 'loaded');
 	const sceneFailed = $derived(sceneMediaState === 'error');
 
-	const syncStudioMotion = () => {
-		cameraX = studioMotion.cameraX;
-		cameraZoom = studioMotion.zoom;
-		cameraDepth = studioMotion.cameraDepth;
-		cameraHeight = studioMotion.cameraHeight;
-		cameraTargetX = studioMotion.targetX;
-		cameraTargetY = studioMotion.targetY;
-		cameraTargetZ = studioMotion.targetZ;
-		modelRotationX = studioMotion.rotationX;
-		modelRotationY = studioMotion.rotationY;
+	let invalidateFrame: (() => void) | undefined;
+
+	/**
+	 * Applies studioMotion straight onto the three.js objects and requests a
+	 * single frame. Routing this through Svelte state would invalidate the
+	 * effect graph nine times per animation frame while GSAP drives the tween.
+	 */
+	const applyStudioMotion = () => {
+		const camera = studioCamera;
+		const sceneRoot = studioSceneRoot;
+
+		if (camera) {
+			camera.position.set(
+				studioMotion.cameraX,
+				studioMotion.cameraHeight,
+				studioMotion.cameraDepth
+			);
+			camera.zoom = studioMotion.zoom;
+			camera.updateProjectionMatrix();
+			camera.lookAt(studioMotion.targetX, studioMotion.targetY, studioMotion.targetZ);
+		}
+
+		sceneRoot?.rotation.set(studioMotion.rotationX, studioMotion.rotationY, 0);
+
+		if (camera || sceneRoot) {
+			invalidateFrame?.();
+		}
 	};
 
+	/** Re-sync once the camera binds or the GLTF scene finishes loading mid-tween. */
 	$effect(() => {
-		void cameraX;
-		void cameraDepth;
-		void cameraHeight;
-		void cameraTargetX;
-		void cameraTargetY;
-		void cameraTargetZ;
-		if (!studioCamera) return;
-
-		studioCamera.lookAt(cameraTargetX, cameraTargetY, cameraTargetZ);
+		void studioCamera;
+		void studioSceneRoot;
+		applyStudioMotion();
 	});
 
 	$effect(() => {
@@ -165,7 +169,7 @@
 					rotationY: 0,
 					duration: LEFT_WALL_ROTATE_DURATION,
 					ease: 'power3.inOut',
-					onUpdate: syncStudioMotion
+					onUpdate: applyStudioMotion
 				})
 				.to(studioMotion, {
 					cameraX: LEFT_WALL_CAMERA.cameraX,
@@ -178,7 +182,7 @@
 					rotationX: 0,
 					duration: LEFT_WALL_ZOOM_DURATION,
 					ease: 'power4.inOut',
-					onUpdate: syncStudioMotion
+					onUpdate: applyStudioMotion
 				});
 
 			return;
@@ -198,7 +202,7 @@
 				rotationY: TOP_CLOSE_CAMERA.rotationY,
 				duration: TOP_CLOSE_ENTER_DURATION,
 				ease: 'power3.inOut',
-				onUpdate: syncStudioMotion
+				onUpdate: applyStudioMotion
 			});
 
 			return;
@@ -219,13 +223,13 @@
 					rotationX: -0.22,
 					duration: LEFT_WALL_EXIT_ZOOM_DURATION,
 					ease: 'power3.out',
-					onUpdate: syncStudioMotion
+					onUpdate: applyStudioMotion
 				})
 				.to(studioMotion, {
 					rotationY: -Math.PI / 4,
 					duration: LEFT_WALL_EXIT_ROTATE_DURATION,
 					ease: 'power3.inOut',
-					onUpdate: syncStudioMotion
+					onUpdate: applyStudioMotion
 				});
 
 			return;
@@ -246,13 +250,13 @@
 					rotationX: -0.22,
 					duration: TOP_CLOSE_EXIT_DURATION,
 					ease: 'power3.inOut',
-					onUpdate: syncStudioMotion
+					onUpdate: applyStudioMotion
 				})
 				.to(studioMotion, {
 					rotationY: -Math.PI / 4,
 					duration: 0.8,
 					ease: 'power3.inOut',
-					onUpdate: syncStudioMotion
+					onUpdate: applyStudioMotion
 				});
 
 			return;
@@ -272,7 +276,7 @@
 				rotationY: 0,
 				duration: RESET_DURATION,
 				ease: 'power3.out',
-				onUpdate: syncStudioMotion
+				onUpdate: applyStudioMotion
 			});
 
 			return;
@@ -291,15 +295,9 @@
 				rotationX: -0.22,
 				rotationY: 0
 			});
-			cameraX = 0;
-			cameraZoom = 40;
-			cameraDepth = 16;
-			cameraHeight = 7.8;
-			cameraTargetX = 0;
-			cameraTargetY = 0.8;
-			cameraTargetZ = 0;
-			modelRotationX = -0.22;
-			modelRotationY = 0;
+			// untrack: applyStudioMotion reads studioCamera/studioSceneRoot, which must
+			// not become dependencies of this pose effect.
+			untrack(applyStudioMotion);
 			return;
 		}
 
@@ -317,7 +315,7 @@
 				rotationX: -0.22,
 				duration: ENTER_DURATION,
 				ease: 'power4.inOut',
-				onUpdate: syncStudioMotion
+				onUpdate: applyStudioMotion
 			})
 			.to(
 				studioMotion,
@@ -325,7 +323,7 @@
 					rotationY: -Math.PI / 4,
 					duration: ENTER_DURATION - 0.55,
 					ease: 'power3.inOut',
-					onUpdate: syncStudioMotion
+					onUpdate: applyStudioMotion
 				},
 				0.55
 			);
@@ -348,18 +346,16 @@
 			<T.OrthographicCamera
 				bind:ref={studioCamera}
 				makeDefault
-				position={[cameraX, cameraHeight, cameraDepth]}
-				zoom={cameraZoom}
-				oncreate={(camera) => camera.lookAt(cameraTargetX, cameraTargetY, cameraTargetZ)}
-			>
-				<OrbitControls
-					autoRotate={false}
-					enablePan={false}
-					enableZoom={false}
-					enableRotate={false}
-					enableDamping
-				/>
-			</T.OrthographicCamera>
+				position={[initialCamera.cameraX, initialCamera.cameraHeight, initialCamera.cameraDepth]}
+				zoom={initialCamera.zoom}
+				oncreate={(camera) =>
+					camera.lookAt(initialCamera.targetX, initialCamera.targetY, initialCamera.targetZ)}
+			/>
+			<SceneFrameInvalidator
+				onready={(invalidate) => {
+					invalidateFrame = invalidate;
+				}}
+			/>
 			<T.Color attach="background" args={['#d7c2a8']} />
 			<T.Fog args={['#d7c2a8', 14, 32]} />
 			<T.AmbientLight intensity={0.08} />
@@ -379,7 +375,7 @@
 				url="/models/studio-transformed.glb"
 				scale={5.7}
 				position={[0, -6, 0]}
-				rotation={[modelRotationX, modelRotationY, 0]}
+				rotation={[initialCamera.rotationX, initialCamera.rotationY, 0]}
 				castShadow
 				receiveShadow
 				onload={() => {

--- a/apps/web/src/lib/features/stroke-json/drafts.spec.ts
+++ b/apps/web/src/lib/features/stroke-json/drafts.spec.ts
@@ -324,6 +324,92 @@ describe('stroke-json drafts', () => {
 		expect(storage.getItem(legacyKey)).toBeNull();
 	});
 
+	it('persists the seeded baseline and keeps it intact across strokes and compaction', async () => {
+		const draftStore = createIndexedDbDrawingDraftStore({ databaseName: TEST_DATABASE_NAME });
+		const draftKey = buildDrawingDraftKey({
+			schemaVersion: 2,
+			scope: 'artwork-parent',
+			surface: 'artwork',
+			userKey: 'artist_1'
+		});
+		const session = createDrawingDraftSession({ draftKey, store: draftStore });
+		const seedDocument = createEmptyDrawingDocumentV2('artwork');
+		seedDocument.tail.push(
+			createStroke({
+				points: [
+					[48, 48],
+					[180, 180]
+				]
+			})
+		);
+
+		const hydrated = await session.hydrate({ seedDocument });
+		if (!hydrated) {
+			throw new Error('Expected the draft session to hydrate the seeded fork document');
+		}
+
+		const withStroke = await session.appendCommittedStroke(
+			hydrated,
+			createStroke({
+				color: '#c84f4f',
+				points: [
+					[220, 240],
+					[280, 320]
+				]
+			})
+		);
+		await session.compact(withStroke);
+
+		expect(await session.hydrate()).toEqual(withStroke);
+		expect(await session.loadBaseline()).toEqual(seedDocument);
+	});
+
+	it('returns no baseline for drafts persisted before baseline tracking existed', async () => {
+		const draftStore = createIndexedDbDrawingDraftStore({ databaseName: TEST_DATABASE_NAME });
+		const draftKey = buildDrawingDraftKey({
+			schemaVersion: 2,
+			scope: 'artwork-parent',
+			surface: 'artwork',
+			userKey: 'artist_1'
+		});
+		const legacyDocument = createEmptyDrawingDocumentV2('artwork');
+		legacyDocument.tail.push(
+			createStroke({
+				points: [
+					[20, 20],
+					[64, 64]
+				]
+			})
+		);
+
+		await draftStore.writeSnapshot({ draftKey, document: legacyDocument });
+
+		expect(await draftStore.readBaseline(draftKey)).toBeNull();
+		expect(
+			await createDrawingDraftSession({ draftKey, store: draftStore }).loadBaseline()
+		).toBeNull();
+	});
+
+	it('clears the persisted baseline together with the draft snapshot and journal', async () => {
+		const draftStore = createIndexedDbDrawingDraftStore({ databaseName: TEST_DATABASE_NAME });
+		const draftKey = buildDrawingDraftKey({
+			schemaVersion: 2,
+			scope: 'artwork-parent',
+			surface: 'artwork',
+			userKey: 'artist_1'
+		});
+		const session = createDrawingDraftSession({ draftKey, store: draftStore });
+		const seedDocument = createEmptyDrawingDocumentV2('artwork');
+
+		await session.hydrate({ seedDocument });
+		expect(await session.loadBaseline()).toEqual(seedDocument);
+
+		await session.clear();
+
+		expect(await session.loadBaseline()).toBeNull();
+		expect(await draftStore.hydrate(draftKey)).toBeNull();
+	});
+
 	it('compacts a session into a fresh snapshot without changing the hydrated document', async () => {
 		const draftStore = createIndexedDbDrawingDraftStore({ databaseName: TEST_DATABASE_NAME });
 		const draftKey = buildDrawingDraftKey({

--- a/apps/web/src/lib/features/stroke-json/drafts.ts
+++ b/apps/web/src/lib/features/stroke-json/drafts.ts
@@ -70,6 +70,8 @@ export type IndexedDbDrawingDraftStore = {
 	compact: (input: WriteSnapshotInput) => Promise<void>;
 	hydrate: (draftKey: string) => Promise<DrawingDocumentV2 | null>;
 	listJournalEntries: (draftKey: string) => Promise<DrawingStroke[]>;
+	readBaseline: (draftKey: string) => Promise<DrawingDocumentV2 | null>;
+	writeBaseline: (input: WriteSnapshotInput) => Promise<void>;
 	writeSnapshot: (input: WriteSnapshotInput) => Promise<void>;
 };
 
@@ -81,6 +83,7 @@ export type DrawingDraftSession = {
 	clear: () => Promise<void>;
 	compact: (document: DrawingDocumentV2) => Promise<void>;
 	hydrate: (input?: DrawingDraftSessionHydrateInput) => Promise<DrawingDocumentV2 | null>;
+	loadBaseline: () => Promise<DrawingDocumentV2 | null>;
 };
 
 const DRAWING_DRAFTS_DB_NAME = 'drawing-drafts';
@@ -89,6 +92,9 @@ const SNAPSHOT_STORE = 'snapshots';
 const JOURNAL_STORE = 'journal';
 const JOURNAL_BY_DRAFT_SEQUENCE_INDEX = 'by-draft-sequence';
 const DEFAULT_MAX_JOURNAL_ENTRIES_BEFORE_COMPACT = 24;
+const BASELINE_DRAFT_KEY_PREFIX = 'baseline:';
+
+const buildBaselineDraftKey = (draftKey: string) => `${BASELINE_DRAFT_KEY_PREFIX}${draftKey}`;
 
 const cloneDrawingStroke = (stroke: DrawingStroke): DrawingStroke => ({
 	color: stroke.color,
@@ -213,6 +219,7 @@ const clearPersistedDraftData = async (options: OpenDraftStoreOptions, draftKey:
 	await withDatabase(options, async (database) => {
 		const transaction = database.transaction([SNAPSHOT_STORE, JOURNAL_STORE], 'readwrite');
 		getSnapshotStore(transaction).delete(draftKey);
+		getSnapshotStore(transaction).delete(buildBaselineDraftKey(draftKey));
 		await deleteJournalEntries(getJournalStore(transaction), draftKey);
 		await waitForTransaction(transaction);
 	});
@@ -304,6 +311,27 @@ export const createIndexedDbDrawingDraftStore = (
 		(
 			await withDatabase(options, async (database) => await getJournalRecords(database, draftKey))
 		).map((journalRecord) => normalizeJournalStroke(journalRecord.stroke)),
+	readBaseline: async (draftKey) => {
+		try {
+			return await withDatabase(options, async (database) => {
+				const baselineRecord = await getSnapshotRecord(database, buildBaselineDraftKey(draftKey));
+				return baselineRecord ? normalizeSnapshotDocument(baselineRecord.document) : null;
+			});
+		} catch {
+			return null;
+		}
+	},
+	writeBaseline: async ({ draftKey, document }) => {
+		await withDatabase(options, async (database) => {
+			const transaction = database.transaction([SNAPSHOT_STORE], 'readwrite');
+			getSnapshotStore(transaction).put({
+				draftKey: buildBaselineDraftKey(draftKey),
+				document: normalizeSnapshotDocument(document),
+				updatedAt: Date.now()
+			} satisfies DraftSnapshotRecord);
+			await waitForTransaction(transaction);
+		});
+	},
 	writeSnapshot: async ({ draftKey, document }) => {
 		await withDatabase(options, async (database) => {
 			const transaction = database.transaction([SNAPSHOT_STORE], 'readwrite');
@@ -362,8 +390,10 @@ export const createDrawingDraftSession = (
 
 			const seedDocument = cloneDrawingDocumentV2(options.seedDocument);
 			await store.writeSnapshot({ document: seedDocument, draftKey: input.draftKey });
+			await store.writeBaseline({ document: seedDocument, draftKey: input.draftKey });
 			return seedDocument;
-		}
+		},
+		loadBaseline: async () => await store.readBaseline(input.draftKey)
 	};
 };
 

--- a/apps/web/src/lib/features/studio-drawing/StudioDrawingPage.svelte
+++ b/apps/web/src/lib/features/studio-drawing/StudioDrawingPage.svelte
@@ -186,6 +186,7 @@
 	let draftHydrated = $state(false);
 	let drawingDocument = $state<DrawingDocumentV2>(createEmptyDrawingDocumentV2('artwork'));
 	let initialDrawingDocument = $state<DrawingDocumentV2>(createEmptyDrawingDocumentV2('artwork'));
+	let artworkBaselineDocument = $state<DrawingDocumentV2>(createEmptyDrawingDocumentV2('artwork'));
 	let forkPreloadSettled = $state(true);
 	let isPublishing = $state(false);
 	let isMobileViewport = $state(false);
@@ -340,6 +341,7 @@
 				? cloneDrawingDocumentV2(resolvedForkParent.drawingDocument)
 				: createEmptyDrawingDocumentV2('artwork');
 			initialDrawingDocument = cloneDrawingDocumentV2(drawingDocument);
+			artworkBaselineDocument = cloneDrawingDocumentV2(drawingDocument);
 			draftHydrated = true;
 			return () => {
 				draftLoadCancelled = true;
@@ -354,11 +356,17 @@
 
 		void draftSession!
 			.hydrate({ seedDocument })
-			.then((draft) => {
+			.then(async (draft) => {
+				if (draftLoadCancelled) return;
+
+				const persistedBaseline = await draftSession!.loadBaseline().catch(() => null);
 				if (draftLoadCancelled) return;
 
 				drawingDocument = draft?.kind === 'artwork' ? draft : seedDocument;
 				initialDrawingDocument = cloneDrawingDocumentV2(drawingDocument);
+				artworkBaselineDocument = cloneDrawingDocumentV2(
+					persistedBaseline?.kind === 'artwork' ? persistedBaseline : seedDocument
+				);
 				draftHydrated = true;
 				clearUnsavedDraftWarning();
 			})
@@ -367,6 +375,7 @@
 
 				drawingDocument = cloneDrawingDocumentV2(seedDocument);
 				initialDrawingDocument = cloneDrawingDocumentV2(seedDocument);
+				artworkBaselineDocument = cloneDrawingDocumentV2(seedDocument);
 				draftHydrated = true;
 				markUnsavedDraftWarning();
 			});
@@ -384,8 +393,9 @@
 
 	const clearCanvas = () => {
 		if (!studioUnlocked) return;
-		drawingDocument = cloneDrawingDocumentV2(initialDrawingDocument);
-		void resetDraftSession(initialDrawingDocument);
+		drawingDocument = cloneDrawingDocumentV2(artworkBaselineDocument);
+		initialDrawingDocument = cloneDrawingDocumentV2(artworkBaselineDocument);
+		void resetDraftSession(artworkBaselineDocument);
 		clearVersion += 1;
 		publishedArtwork = null;
 		statusMessage = '';
@@ -404,6 +414,7 @@
 		void createDraftSession(previousDraftKeys.draftKey, previousDraftKeys.legacyDraftKey)?.clear();
 		currentForkParent = null;
 		initialDrawingDocument = cloneDrawingDocumentV2(emptyDocument);
+		artworkBaselineDocument = cloneDrawingDocumentV2(emptyDocument);
 		drawingDocument = cloneDrawingDocumentV2(emptyDocument);
 		clearVersion += 1;
 		artworkTitle = '';
@@ -555,7 +566,8 @@
 				} else {
 					const draftSession = createDraftSession(draftKey, legacyDraftKey);
 					void draftSession?.clear();
-					drawingDocument = cloneDrawingDocumentV2(initialDrawingDocument);
+					drawingDocument = cloneDrawingDocumentV2(artworkBaselineDocument);
+					initialDrawingDocument = cloneDrawingDocumentV2(artworkBaselineDocument);
 					clearVersion += 1;
 					artworkTitle = '';
 					isArtworkNsfw = false;

--- a/apps/web/src/lib/features/studio-drawing/StudioDrawingPage.svelte.spec.ts
+++ b/apps/web/src/lib/features/studio-drawing/StudioDrawingPage.svelte.spec.ts
@@ -836,6 +836,68 @@ describe('StudioDrawingPage', () => {
 		});
 	});
 
+	it('clears back to the fork base after a reload that compacted the draft', async () => {
+		const forkParentDocument = normalizeDrawingDocumentToEditableV2({
+			...createEmptyDrawingDocument('artwork'),
+			strokes: [
+				{
+					color: '#2d2420',
+					points: [[48, 48] as [number, number], [180, 180] as [number, number]],
+					size: 8
+				}
+			]
+		});
+		const compactedDraftDocument = normalizeDrawingDocumentToEditableV2({
+			...createEmptyDrawingDocument('artwork'),
+			strokes: [
+				{
+					color: '#2d2420',
+					points: [[48, 48] as [number, number], [180, 180] as [number, number]],
+					size: 8
+				},
+				{
+					color: '#c84f4f',
+					points: [[220, 240] as [number, number], [280, 320] as [number, number]],
+					size: 10
+				}
+			]
+		});
+		const draftKey = buildDrawingDraftKey({
+			schemaVersion: DRAWING_DOCUMENT_V2_VERSION,
+			scope: 'artwork-parent',
+			surface: 'artwork',
+			userKey: 'journey_artist'
+		});
+		const draftStore = createIndexedDbDrawingDraftStore();
+		await draftStore.writeSnapshot({ draftKey, document: compactedDraftDocument });
+		await draftStore.writeBaseline({ draftKey, document: forkParentDocument });
+		window.localStorage.setItem(
+			'studio-fork-context:journey_artist',
+			JSON.stringify({
+				id: 'artwork-parent',
+				isNsfw: false,
+				mediaUrl: forkParentPreviewDataUrl,
+				title: 'Parent Artwork'
+			})
+		);
+
+		render(StudioDrawingPage, {
+			openingDurationMs: 1,
+			user: { nickname: 'journey_artist' }
+		});
+
+		await expect.element(page.getByRole('button', { name: 'Publish' })).toBeVisible();
+		await expect.element(page.getByPlaceholder('Untitled genius')).toBeEnabled();
+
+		await page.getByRole('button', { name: 'Clear' }).click();
+
+		await vi.waitFor(async () => {
+			const persistedDraft = await readPersistedDrawingDraft(draftKey);
+			expect(persistedDraft?.tail).toEqual(forkParentDocument.tail);
+			expect(await readPersistedJournalEntries(draftKey)).toEqual([]);
+		});
+	});
+
 	it('stores only lightweight fork resume metadata in localStorage', async () => {
 		render(StudioDrawingPage, {
 			forkParent: {


### PR DESCRIPTION
## What changes

Replace the GSAP timeline-based wall zoom with **Web Animations API** calls that use only `transform` and `opacity`, keeping the entire animation off the main thread. Rasterize the wall pattern, graffiti logo, and window frame SVGs to bitmaps after mount so the zoom never triggers SVG re-rasterization.

In `StudioScene`, write `studioMotion` directly to three.js objects instead of routing through nine Svelte state variables (one invalidation per tween frame instead of nine). Remove `OrbitControls` and add `SceneFrameInvalidator` for explicit render scheduling.

Also: persist artwork baseline for post-reload clearing, and ignore `.atl` local runtime directory.

## Why

The Come In animation was janky on low-end devices because:
1. GSAP ran on the main thread, competing with Svelte rendering.
2. SVG re-rasterization on every zoom frame was expensive.
3. Nine Svelte state invalidations per tween frame caused unnecessary DOM work.

## Testing

- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run check`
- [x] `bun run test`

## Notes for review

- `museum-wall-zoom.ts` and `svg-bitmap.ts` are new modules — focus review there.
- `MuseumWallOverlay.svelte` had significant refactoring (325 lines changed).
- `StudioScene.svelte` now writes directly to three.js objects; verify render correctness.