### PR TITLE
build(deploy): make the project deployable on Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# A single in-flight deployment at a time; newer pushes supersede older runs.
+concurrency:
+  group: deploy-cloudflare-workers
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy worker
+    runs-on: ubuntu-latest
+    # GitHub environment "production" can gate this with required reviewers and
+    # is where the Cloudflare credentials below are stored.
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # The Rust-built stroke-json WASM is committed under
+      # packages/stroke-json-runtime/generated, so no Rust toolchain is needed
+      # here. `bun run build` smoke-tests that artifact, then runs the SvelteKit
+      # adapter-cloudflare build into apps/web/.svelte-kit/cloudflare.
+      - name: Build
+        run: bun run build
+
+      - name: Deploy with Wrangler
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/web
+          # The build already ran above; just upload the prebuilt output.
+          command: deploy

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -11,3 +11,5 @@ vite.config.ts.timestamp-*
 .env.*
 !.env.example
 !.env.test
+.wrangler
+.dev.vars

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,13 @@
 	},
 	"dependencies": {
 		"@2toad/profanity": "^3.3.0",
+		"@jsquash/avif": "^2.1.1",
+		"@jsquash/jpeg": "^1.6.0",
+		"@jsquash/png": "^3.1.1",
+		"@jsquash/resize": "^2.1.1",
+		"@jsquash/webp": "^1.5.0",
 		"@not-the-louvre/stroke-json-runtime": "workspace:*",
+		"@resvg/resvg-wasm": "^2.6.2",
 		"@supabase/supabase-js": "^2.100.1",
 		"@threlte/core": "^8.5.2",
 		"@threlte/extras": "^9.13.0",
@@ -42,7 +48,6 @@
 		"jose": "^6.2.2",
 		"lucide-svelte": "^1.0.1",
 		"postgres": "^3.4.8",
-		"sharp": "^0.34.5",
 		"three": "^0.183.2",
 		"virtua": "^0.49.0",
 		"zod": "^4.3.6"
@@ -53,6 +58,7 @@
 		"@eslint/js": "^10.0.1",
 		"@playwright/test": "^1.58.2",
 		"@sveltejs/adapter-auto": "^7.0.0",
+		"@sveltejs/adapter-cloudflare": "^7.2.8",
 		"@sveltejs/adapter-node": "^5.3.2",
 		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -70,6 +76,7 @@
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.4.1",
 		"prettier-plugin-tailwindcss": "^0.7.2",
+		"sharp": "^0.34.5",
 		"svelte": "^5.54.0",
 		"svelte-check": "^4.4.2",
 		"tailwindcss": "^4.1.18",
@@ -77,6 +84,7 @@
 		"typescript-eslint": "^8.57.0",
 		"vite": "^7.3.1",
 		"vitest": "^4.1.0",
-		"vitest-browser-svelte": "^2.0.2"
+		"vitest-browser-svelte": "^2.0.2",
+		"wrangler": "^4.100.0"
 	}
 }

--- a/apps/web/scripts/build-production.ts
+++ b/apps/web/scripts/build-production.ts
@@ -2,12 +2,14 @@ import { mkdir, rm, symlink } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import process from 'node:process';
 import {
-	DEFAULT_BUILD_DIR,
-	ensureBuildManifestExcludesRoutePrefix,
-	ensureBuildOutput,
+	DEFAULT_CLOUDFLARE_BUILD_DIR,
+	DEFAULT_CLOUDFLARE_MANIFEST_PATH,
+	ensureManifestFileExcludesRoutePrefix,
 	ensureServerDependencyBundled,
 	ensureServerWasmAsset,
+	ensureServerWasmModuleExternalized,
 	ensureServerWasmReferenced,
+	ensureWorkerBuildOutput,
 	syncGeneratedServerWasmAsset,
 	syncProductionRoutes
 } from '../src/lib/server/deploy/build';
@@ -19,7 +21,9 @@ const generatedSourceDirectory = resolve(projectRoot, '.generated/production-src
 const targetRoutesDirectory = resolve(generatedSourceDirectory, 'routes');
 const generatedLibDirectory = resolve(generatedSourceDirectory, 'lib');
 const sourceLibDirectory = resolve(projectRoot, 'src/lib');
-const buildDirectory = resolve(projectRoot, DEFAULT_BUILD_DIR);
+const cloudflareBuildDirectory = resolve(projectRoot, DEFAULT_CLOUDFLARE_BUILD_DIR);
+const cloudflareManifestPath = resolve(projectRoot, DEFAULT_CLOUDFLARE_MANIFEST_PATH);
+const svelteKitOutputDirectory = resolve(projectRoot, '.svelte-kit/output');
 const generatedServerWasmPath = resolve(
 	projectRoot,
 	'../../packages/stroke-json-runtime/generated/wasm/server/stroke_json_wasm_bg.wasm'
@@ -58,15 +62,23 @@ try {
 		throw new Error(`vite build failed with exit code ${exitCode}`);
 	}
 
-	await ensureBuildOutput(buildDirectory);
-	await ensureServerDependencyBundled(buildDirectory, 'gsap');
-	await ensureServerDependencyBundled(buildDirectory, '@not-the-louvre/stroke-json-runtime/server');
-	await ensureBuildManifestExcludesRoutePrefix(buildDirectory, '/demo');
-	await syncGeneratedServerWasmAsset(buildDirectory, generatedServerWasmPath);
-	await ensureServerWasmAsset(buildDirectory);
-	await ensureServerWasmReferenced(buildDirectory);
+	await ensureWorkerBuildOutput(cloudflareBuildDirectory);
+	await ensureServerDependencyBundled(svelteKitOutputDirectory, 'gsap');
+	await ensureServerDependencyBundled(
+		svelteKitOutputDirectory,
+		'@not-the-louvre/stroke-json-runtime/server'
+	);
+	await ensureManifestFileExcludesRoutePrefix(cloudflareManifestPath, '/demo');
+	await ensureServerWasmModuleExternalized(svelteKitOutputDirectory);
+	// `vite preview` still serves the SSR output with Node, which loads the wasm
+	// from disk relative to the emitted chunks.
+	await syncGeneratedServerWasmAsset(svelteKitOutputDirectory, generatedServerWasmPath);
+	await ensureServerWasmAsset(svelteKitOutputDirectory);
+	await ensureServerWasmReferenced(svelteKitOutputDirectory);
 
-	process.stdout.write(`Validated adapter-node build output at ${buildDirectory}\n`);
+	process.stdout.write(
+		`Validated adapter-cloudflare build output at ${cloudflareBuildDirectory}\n`
+	);
 } finally {
 	await rm(generatedSourceDirectory, { force: true, recursive: true });
 }

--- a/apps/web/scripts/validate-build-output.ts
+++ b/apps/web/scripts/validate-build-output.ts
@@ -1,21 +1,29 @@
 import { resolve } from 'node:path';
 import process from 'node:process';
 import {
-	DEFAULT_BUILD_DIR,
-	ensureBuildManifestExcludesRoutePrefix,
-	ensureBuildOutput,
+	DEFAULT_CLOUDFLARE_BUILD_DIR,
+	DEFAULT_CLOUDFLARE_MANIFEST_PATH,
+	ensureManifestFileExcludesRoutePrefix,
 	ensureServerDependencyBundled,
 	ensureServerWasmAsset,
-	ensureServerWasmReferenced
+	ensureServerWasmModuleExternalized,
+	ensureServerWasmReferenced,
+	ensureWorkerBuildOutput
 } from '../src/lib/server/deploy/build';
 
-const buildDir = resolve(process.cwd(), DEFAULT_BUILD_DIR);
+const cloudflareBuildDirectory = resolve(process.cwd(), DEFAULT_CLOUDFLARE_BUILD_DIR);
+const cloudflareManifestPath = resolve(process.cwd(), DEFAULT_CLOUDFLARE_MANIFEST_PATH);
+const svelteKitOutputDirectory = resolve(process.cwd(), '.svelte-kit/output');
 
-await ensureBuildOutput(buildDir);
-await ensureServerDependencyBundled(buildDir, 'gsap');
-await ensureServerDependencyBundled(buildDir, '@not-the-louvre/stroke-json-runtime/server');
-await ensureBuildManifestExcludesRoutePrefix(buildDir, '/demo');
-await ensureServerWasmAsset(buildDir);
-await ensureServerWasmReferenced(buildDir);
+await ensureWorkerBuildOutput(cloudflareBuildDirectory);
+await ensureServerDependencyBundled(svelteKitOutputDirectory, 'gsap');
+await ensureServerDependencyBundled(
+	svelteKitOutputDirectory,
+	'@not-the-louvre/stroke-json-runtime/server'
+);
+await ensureManifestFileExcludesRoutePrefix(cloudflareManifestPath, '/demo');
+await ensureServerWasmModuleExternalized(svelteKitOutputDirectory);
+await ensureServerWasmAsset(svelteKitOutputDirectory);
+await ensureServerWasmReferenced(svelteKitOutputDirectory);
 
-process.stdout.write(`Validated adapter-node build output at ${buildDir}\n`);
+process.stdout.write(`Validated adapter-cloudflare build output at ${cloudflareBuildDirectory}\n`);

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { json, type Handle } from '@sveltejs/kit';
 import { building } from '$app/environment';
 import { auth } from '$lib/server/auth';
 import { resolveSessionContext } from '$lib/server/auth/service';
+import { runWithRequestDbConnection } from '$lib/server/db';
 import { logSecurityEvent } from '$lib/server/security/logging';
 import { getTrustedOriginDecision } from '$lib/server/security/trusted-origin';
 import { svelteKitHandler } from 'better-auth/svelte-kit';
@@ -49,4 +50,5 @@ const handleBetterAuth: Handle = async ({ event, resolve }) => {
 	return svelteKitHandler({ event, resolve, auth, building });
 };
 
-export const handle: Handle = handleBetterAuth;
+export const handle: Handle = (input) =>
+	runWithRequestDbConnection(async () => handleBetterAuth(input));

--- a/apps/web/src/lib/server/db/index.ts
+++ b/apps/web/src/lib/server/db/index.ts
@@ -1,10 +1,78 @@
-import { drizzle } from 'drizzle-orm/postgres-js';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
 import { env } from '$env/dynamic/private';
 
 if (!env.DATABASE_URL) throw new Error('DATABASE_URL is not set');
 
-export const dbClient = postgres(env.DATABASE_URL);
+type DbConnection = {
+	client: ReturnType<typeof postgres>;
+	db: PostgresJsDatabase<typeof schema>;
+};
 
-export const db = drizzle(dbClient, { schema });
+const createDbConnection = (): DbConnection => {
+	const client = postgres(env.DATABASE_URL);
+
+	return { client, db: drizzle(client, { schema }) };
+};
+
+// Cloudflare Workers forbid using a TCP socket opened during one request from
+// another request, so a module-level connection pool breaks there. Each
+// request runs inside this storage with its own connection (see
+// hooks.server.ts), while Node keeps the usual process-wide pool.
+const requestScopedConnection = new AsyncLocalStorage<DbConnection>();
+
+const runningInCloudflareWorkers =
+	typeof caches !== 'undefined' &&
+	(caches as unknown as { default?: unknown }).default !== undefined;
+
+let processConnection: DbConnection | undefined;
+
+const resolveConnection = (): DbConnection => {
+	const scoped = requestScopedConnection.getStore();
+
+	if (scoped) {
+		return scoped;
+	}
+
+	processConnection ??= createDbConnection();
+
+	return processConnection;
+};
+
+export const runWithRequestDbConnection = async <T>(fn: () => Promise<T>): Promise<T> => {
+	if (!runningInCloudflareWorkers) {
+		return fn();
+	}
+
+	const connection = createDbConnection();
+
+	try {
+		return await requestScopedConnection.run(connection, fn);
+	} finally {
+		// Waits for in-flight queries before closing the request's connection.
+		void connection.client.end({ timeout: 5 }).catch(() => undefined);
+	}
+};
+
+const createConnectionBoundProxy = <T extends object>(resolveTarget: () => T): T =>
+	new Proxy(function () {} as unknown as T, {
+		apply: (_target, _thisArg, args) =>
+			Reflect.apply(
+				resolveTarget() as unknown as (...callArgs: unknown[]) => unknown,
+				undefined,
+				args
+			),
+		get: (_target, property) => {
+			const target = resolveTarget();
+			const value = Reflect.get(target, property, target);
+
+			return typeof value === 'function' ? value.bind(target) : value;
+		},
+		has: (_target, property) => property in resolveTarget()
+	});
+
+export const dbClient = createConnectionBoundProxy(() => resolveConnection().client);
+
+export const db = createConnectionBoundProxy(() => resolveConnection().db);

--- a/apps/web/src/lib/server/deploy/build.test.ts
+++ b/apps/web/src/lib/server/deploy/build.test.ts
@@ -4,10 +4,13 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
 	ensureServerWasmAsset,
+	ensureServerWasmModuleExternalized,
 	ensureServerWasmReferenced,
 	ensureBuildManifestExcludesRoutePrefix,
 	ensureBuildOutput,
 	ensureServerDependencyBundled,
+	ensureWorkerBuildOutput,
+	SERVER_WASM_IMPORT_SPECIFIER,
 	syncGeneratedServerWasmAsset,
 	syncProductionRoutes
 } from './build';
@@ -153,6 +156,50 @@ describe('ensureBuildOutput', () => {
 		);
 
 		await expect(ensureServerWasmReferenced(buildDir)).resolves.toContain('_runtime.js');
+	});
+});
+
+describe('ensureWorkerBuildOutput', () => {
+	it('returns the worker entrypoint when the adapter-cloudflare output exists', async () => {
+		const buildDir = join(tmpdir(), `ntl-cf-build-${crypto.randomUUID()}`);
+		await mkdir(buildDir, { recursive: true });
+		await writeFile(join(buildDir, '_worker.js'), 'export default { fetch: () => {} };');
+
+		await expect(ensureWorkerBuildOutput(buildDir)).resolves.toBe(join(buildDir, '_worker.js'));
+	});
+
+	it('throws when the worker entrypoint is missing', async () => {
+		const buildDir = join(tmpdir(), `ntl-cf-build-${crypto.randomUUID()}`);
+		await mkdir(buildDir, { recursive: true });
+
+		await expect(ensureWorkerBuildOutput(buildDir)).rejects.toThrow(
+			'Expected adapter-cloudflare build output at'
+		);
+	});
+});
+
+describe('ensureServerWasmModuleExternalized', () => {
+	it('passes when a server chunk imports the wasm module specifier', async () => {
+		const buildDir = join(tmpdir(), `ntl-cf-wasm-${crypto.randomUUID()}`);
+		const serverDir = join(buildDir, 'server', 'chunks');
+		await mkdir(serverDir, { recursive: true });
+		await writeFile(
+			join(serverDir, '_runtime.js'),
+			`const wasmModule = await import('${SERVER_WASM_IMPORT_SPECIFIER}');\nexport { wasmModule };`
+		);
+
+		await expect(ensureServerWasmModuleExternalized(buildDir)).resolves.toContain('_runtime.js');
+	});
+
+	it('throws when no server chunk references the wasm module specifier', async () => {
+		const buildDir = join(tmpdir(), `ntl-cf-wasm-${crypto.randomUUID()}`);
+		const serverDir = join(buildDir, 'server', 'chunks');
+		await mkdir(serverDir, { recursive: true });
+		await writeFile(join(serverDir, '_page.js'), 'export const noop = true;');
+
+		await expect(ensureServerWasmModuleExternalized(buildDir)).rejects.toThrow(
+			'Expected SSR build to keep an external import of'
+		);
 	});
 });
 

--- a/apps/web/src/lib/server/deploy/build.ts
+++ b/apps/web/src/lib/server/deploy/build.ts
@@ -2,6 +2,13 @@ import { access, copyFile, cp, mkdir, readdir, readFile, rm } from 'node:fs/prom
 import { dirname, join, relative, resolve } from 'node:path';
 
 export const DEFAULT_BUILD_DIR = 'build';
+export const DEFAULT_CLOUDFLARE_BUILD_DIR = join('.svelte-kit', 'cloudflare');
+export const DEFAULT_CLOUDFLARE_MANIFEST_PATH = join(
+	'.svelte-kit',
+	'cloudflare-tmp',
+	'manifest.js'
+);
+export const SERVER_WASM_IMPORT_SPECIFIER = '@not-the-louvre/stroke-json-runtime/server.wasm';
 export const GENERATED_SERVER_WASM_RELATIVE_PATH = join(
 	'generated',
 	'wasm',
@@ -64,6 +71,39 @@ export const ensureBuildOutput = async (buildDirectory: string) => {
 	return entryPoint;
 };
 
+export const ensureWorkerBuildOutput = async (cloudflareBuildDirectory: string) => {
+	const workerEntryPoint = join(cloudflareBuildDirectory, '_worker.js');
+
+	try {
+		await access(workerEntryPoint);
+	} catch {
+		throw new Error(
+			`Expected adapter-cloudflare build output at ${cloudflareBuildDirectory} (missing _worker.js)`
+		);
+	}
+
+	return workerEntryPoint;
+};
+
+// The Workers runtime forbids compiling WASM from bytes, so the SSR output must
+// keep the stroke-json wasm as an external module import for wrangler to bundle.
+export const ensureServerWasmModuleExternalized = async (buildDirectory: string) => {
+	const serverDirectory = join(buildDirectory, 'server');
+	const serverFiles = await collectJavaScriptFiles(serverDirectory);
+
+	for (const serverFile of serverFiles) {
+		const contents = await readFile(serverFile, 'utf8');
+
+		if (contents.includes(SERVER_WASM_IMPORT_SPECIFIER)) {
+			return serverFile;
+		}
+	}
+
+	throw new Error(
+		`Expected SSR build to keep an external import of ${SERVER_WASM_IMPORT_SPECIFIER} under ${serverDirectory}`
+	);
+};
+
 export const ensureServerWasmAsset = async (buildDirectory: string) => {
 	const wasmAssetPath = join(buildDirectory, 'server', GENERATED_SERVER_WASM_RELATIVE_PATH);
 
@@ -104,11 +144,10 @@ export const syncGeneratedServerWasmAsset = async (
 	return targetWasmPath;
 };
 
-export const ensureBuildManifestExcludesRoutePrefix = async (
-	buildDirectory: string,
+export const ensureManifestFileExcludesRoutePrefix = async (
+	manifestPath: string,
 	routePrefix: string
 ) => {
-	const manifestPath = join(buildDirectory, 'server', 'manifest.js');
 	const manifestContents = await readFile(manifestPath, 'utf8');
 	const escapedRoutePrefix = routePrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 	const routePattern = new RegExp(`id:\\s+['"]${escapedRoutePrefix}(?:/|['"])`, 'u');
@@ -119,6 +158,12 @@ export const ensureBuildManifestExcludesRoutePrefix = async (
 		);
 	}
 };
+
+export const ensureBuildManifestExcludesRoutePrefix = (
+	buildDirectory: string,
+	routePrefix: string
+) =>
+	ensureManifestFileExcludesRoutePrefix(join(buildDirectory, 'server', 'manifest.js'), routePrefix);
 
 export const syncProductionRoutes = async (
 	sourceRoutesDirectory: string,

--- a/apps/web/src/lib/server/drawing-document/media.ts
+++ b/apps/web/src/lib/server/drawing-document/media.ts
@@ -1,17 +1,17 @@
-import sharp from 'sharp';
 import {
 	assertDrawingDocumentWithinLimits,
 	type DrawingDocument
 } from '$lib/features/stroke-json/document';
 import { drawingDocumentToSvg } from '$lib/features/stroke-json/svg';
-import { ArtworkFlowError } from '$lib/server/artwork/errors';
 import {
 	ARTWORK_MEDIA_CONTENT_TYPE,
 	ARTWORK_MEDIA_HEIGHT,
 	ARTWORK_MEDIA_MAX_BYTES,
 	ARTWORK_MEDIA_WIDTH
 } from '$lib/server/artwork/config';
+import { ArtworkFlowError } from '$lib/server/artwork/errors';
 import type { SanitizedMedia } from '$lib/server/artwork/types';
+import { encodeAvif, renderSvgToRaster, type AvifEncodeSettings } from '$lib/server/media/codecs';
 import {
 	AVATAR_MEDIA_CONTENT_TYPE,
 	AVATAR_MEDIA_HEIGHT,
@@ -19,27 +19,23 @@ import {
 	AVATAR_MEDIA_WIDTH
 } from '$lib/server/user/config';
 
-const ARTWORK_CANONICAL_AVIF_ATTEMPTS = [
-	{ chromaSubsampling: '4:2:0', effort: 4, quality: 70 },
-	{ chromaSubsampling: '4:2:0', effort: 4, quality: 55 },
-	{ chromaSubsampling: '4:2:0', effort: 4, quality: 42 },
-	{ chromaSubsampling: '4:2:0', effort: 4, quality: 32 }
-] as const;
+const ARTWORK_CANONICAL_AVIF_ATTEMPTS: ReadonlyArray<AvifEncodeSettings> = [
+	{ chromaSubsampling: '4:2:0', quality: 70 },
+	{ chromaSubsampling: '4:2:0', quality: 55 },
+	{ chromaSubsampling: '4:2:0', quality: 42 },
+	{ chromaSubsampling: '4:2:0', quality: 32 }
+];
 
-const AVATAR_CANONICAL_AVIF_ATTEMPTS = [
-	{ chromaSubsampling: '4:4:4', effort: 4, quality: 90 },
-	{ chromaSubsampling: '4:4:4', effort: 4, quality: 75 },
-	{ chromaSubsampling: '4:2:0', effort: 4, quality: 60 }
-] as const;
+const AVATAR_CANONICAL_AVIF_ATTEMPTS: ReadonlyArray<AvifEncodeSettings> = [
+	{ chromaSubsampling: '4:4:4', quality: 90 },
+	{ chromaSubsampling: '4:4:4', quality: 75 },
+	{ chromaSubsampling: '4:2:0', quality: 60 }
+];
 
 const renderDocumentToAvif = async (
 	document: DrawingDocument,
 	options: {
-		attempts: ReadonlyArray<{
-			chromaSubsampling: '4:2:0' | '4:4:4';
-			effort: number;
-			quality: number;
-		}>;
+		attempts: ReadonlyArray<AvifEncodeSettings>;
 		contentType: string;
 		height: number;
 		kind: DrawingDocument['kind'];
@@ -58,17 +54,16 @@ const renderDocumentToAvif = async (
 	}
 
 	assertDrawingDocumentWithinLimits(document);
-	const svgBuffer = Buffer.from(drawingDocumentToSvg(document));
+
+	// The generated SVG paints an opaque background rect, so the raster needs
+	// no extra flattening before encoding.
+	const raster = await renderSvgToRaster(drawingDocumentToSvg(document), {
+		height: options.height,
+		width: options.width
+	});
 
 	for (const avifOptions of options.attempts) {
-		const outputBuffer = await sharp(svgBuffer, { density: 144 })
-			.resize(options.width, options.height, {
-				background: document.background,
-				fit: 'fill'
-			})
-			.flatten({ background: document.background })
-			.avif(avifOptions)
-			.toBuffer();
+		const outputBuffer = await encodeAvif(raster, avifOptions);
 
 		if (outputBuffer.byteLength <= options.maxBytes) {
 			return {

--- a/apps/web/src/lib/server/media/codecs/index.ts
+++ b/apps/web/src/lib/server/media/codecs/index.ts
@@ -1,0 +1,379 @@
+import decodeAvifImage, { init as initAvifDecode } from '@jsquash/avif/decode';
+import encodeAvifImage, { init as initAvifEncode } from '@jsquash/avif/encode';
+import decodeJpegImage, { init as initJpegDecode } from '@jsquash/jpeg/decode';
+import decodePngImage, { init as initPngDecode } from '@jsquash/png/decode';
+import encodePngImage, { init as initPngEncode } from '@jsquash/png/encode';
+import resizeImageData, { initResize } from '@jsquash/resize';
+import decodeWebpImage, { init as initWebpDecode } from '@jsquash/webp/decode';
+import { initWasm as initResvg, Resvg } from '@resvg/resvg-wasm';
+import { ensureImageDataGlobal, loadCodecWasmModule } from './loader';
+import {
+	blitWithAlpha,
+	createSolidImage,
+	cropCenter,
+	type RawImage,
+	type RgbColor
+} from './raster';
+
+export type { RawImage, RgbColor };
+export { applyRoundedRectAlpha, cropCenter, flattenOntoBackground, parseHexColor } from './raster';
+
+export type ImageFormat = 'avif' | 'jpeg' | 'png' | 'webp';
+
+export type AvifEncodeSettings = {
+	chromaSubsampling: '4:2:0' | '4:4:4';
+	quality: number;
+};
+
+ensureImageDataGlobal();
+
+type InitWithWasmModule = (wasmModule: WebAssembly.Module) => Promise<unknown>;
+
+// Bundlers resolve `.wasm` imports to a default-exported WebAssembly.Module, but
+// TypeScript types the dynamic import as the raw module record, so we narrow it.
+const importWasmModule = (loader: () => Promise<unknown>) =>
+	loader() as Promise<{ default: WebAssembly.Module }>;
+
+const codecInitializations = new Map<string, Promise<unknown>>();
+
+const ensureCodec = (
+	cacheKey: string,
+	specifier: string,
+	importWorkersWasmModule: () => Promise<{ default: WebAssembly.Module }>,
+	initialize: InitWithWasmModule
+) => {
+	let initialization = codecInitializations.get(cacheKey);
+
+	if (!initialization) {
+		initialization = loadCodecWasmModule(specifier, importWorkersWasmModule).then(initialize);
+		codecInitializations.set(cacheKey, initialization);
+	}
+
+	return initialization;
+};
+
+const ensureAvifDecode = () =>
+	ensureCodec(
+		'avif-decode',
+		'@jsquash/avif/codec/dec/avif_dec.wasm',
+		() => importWasmModule(() => import('@jsquash/avif/codec/dec/avif_dec.wasm')),
+		initAvifDecode as unknown as InitWithWasmModule
+	);
+
+const ensureAvifEncode = () =>
+	ensureCodec(
+		'avif-encode',
+		'@jsquash/avif/codec/enc/avif_enc.wasm',
+		() => importWasmModule(() => import('@jsquash/avif/codec/enc/avif_enc.wasm')),
+		initAvifEncode as unknown as InitWithWasmModule
+	);
+
+const ensureJpegDecode = () =>
+	ensureCodec(
+		'jpeg-decode',
+		'@jsquash/jpeg/codec/dec/mozjpeg_dec.wasm',
+		() => importWasmModule(() => import('@jsquash/jpeg/codec/dec/mozjpeg_dec.wasm')),
+		initJpegDecode as unknown as InitWithWasmModule
+	);
+
+const ensurePngDecode = () =>
+	ensureCodec(
+		'png-decode',
+		'@jsquash/png/codec/pkg/squoosh_png_bg.wasm',
+		() => importWasmModule(() => import('@jsquash/png/codec/pkg/squoosh_png_bg.wasm')),
+		(wasmModule) => initPngDecode(wasmModule)
+	);
+
+const ensurePngEncode = () =>
+	ensureCodec(
+		'png-encode',
+		'@jsquash/png/codec/pkg/squoosh_png_bg.wasm',
+		() => importWasmModule(() => import('@jsquash/png/codec/pkg/squoosh_png_bg.wasm')),
+		(wasmModule) => initPngEncode(wasmModule)
+	);
+
+const ensureWebpDecode = () =>
+	ensureCodec(
+		'webp-decode',
+		'@jsquash/webp/codec/dec/webp_dec.wasm',
+		() => importWasmModule(() => import('@jsquash/webp/codec/dec/webp_dec.wasm')),
+		initWebpDecode as unknown as InitWithWasmModule
+	);
+
+const ensureResize = () =>
+	ensureCodec(
+		'resize',
+		'@jsquash/resize/lib/resize/pkg/squoosh_resize_bg.wasm',
+		() => importWasmModule(() => import('@jsquash/resize/lib/resize/pkg/squoosh_resize_bg.wasm')),
+		(wasmModule) => initResize(wasmModule)
+	);
+
+const ensureResvg = () =>
+	ensureCodec(
+		'resvg',
+		'@resvg/resvg-wasm/index_bg.wasm',
+		() => importWasmModule(() => import('@resvg/resvg-wasm/index_bg.wasm')),
+		async (wasmModule) => {
+			try {
+				await initResvg(wasmModule);
+			} catch (error) {
+				// resvg keeps its instance in module state shared across module
+				// registries (e.g. vitest isolates); a second init is harmless.
+				if (!(error instanceof Error) || !error.message.includes('Already initialized')) {
+					throw error;
+				}
+			}
+		}
+	);
+
+const JPEG_MAGIC_BYTES = [0xff, 0xd8, 0xff];
+const PNG_MAGIC_BYTES = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const ISO_BMFF_FTYP_OFFSET = 4;
+const ISO_BMFF_BRAND_OFFSET = 8;
+const ISO_BMFF_HEADER_BYTES = 16;
+const ISO_BMFF_BRAND_BYTES = 4;
+const AVIF_STILL_BRAND = 'avif';
+const AVIF_SEQUENCE_BRAND = 'avis';
+
+const readAscii = (input: Uint8Array, start: number, length: number) =>
+	String.fromCharCode(...input.subarray(start, start + length));
+
+const matchesMagicBytes = (input: Uint8Array, magicBytes: ReadonlyArray<number>) =>
+	input.byteLength >= magicBytes.length && magicBytes.every((byte, index) => input[index] === byte);
+
+const containsAscii = (input: Uint8Array, marker: string) => {
+	const markerBytes = marker.split('').map((character) => character.charCodeAt(0));
+
+	for (let offset = 0; offset + markerBytes.length <= input.byteLength; offset += 1) {
+		if (markerBytes.every((byte, index) => input[offset + index] === byte)) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+const collectIsoBmffBrands = (input: Uint8Array) => {
+	const brands = new Set<string>();
+
+	if (
+		input.byteLength < ISO_BMFF_HEADER_BYTES ||
+		readAscii(input, ISO_BMFF_FTYP_OFFSET, ISO_BMFF_BRAND_BYTES) !== 'ftyp'
+	) {
+		return brands;
+	}
+
+	brands.add(readAscii(input, ISO_BMFF_BRAND_OFFSET, ISO_BMFF_BRAND_BYTES));
+
+	for (
+		let offset = ISO_BMFF_HEADER_BYTES;
+		offset + ISO_BMFF_BRAND_BYTES <= input.byteLength;
+		offset += 4
+	) {
+		brands.add(readAscii(input, offset, ISO_BMFF_BRAND_BYTES));
+	}
+
+	return brands;
+};
+
+export const hasAvifMagicBytes = (input: Uint8Array) => {
+	const brands = collectIsoBmffBrands(input);
+
+	return brands.has(AVIF_STILL_BRAND) || brands.has(AVIF_SEQUENCE_BRAND);
+};
+
+export const hasWebpMagicBytes = (input: Uint8Array) =>
+	input.byteLength >= 12 && readAscii(input, 0, 4) === 'RIFF' && readAscii(input, 8, 4) === 'WEBP';
+
+export const sniffImageFormat = (input: Uint8Array): ImageFormat | null => {
+	if (matchesMagicBytes(input, JPEG_MAGIC_BYTES)) {
+		return 'jpeg';
+	}
+
+	if (matchesMagicBytes(input, PNG_MAGIC_BYTES)) {
+		return 'png';
+	}
+
+	if (hasWebpMagicBytes(input)) {
+		return 'webp';
+	}
+
+	if (hasAvifMagicBytes(input)) {
+		return 'avif';
+	}
+
+	return null;
+};
+
+// sharp exposed multi-frame inputs through `metadata.pages`; without it we
+// reject animated containers from their structure before decoding.
+export const isAnimatedImage = (input: Uint8Array, format: ImageFormat) => {
+	if (format === 'webp') {
+		return containsAscii(input, 'ANIM') || containsAscii(input, 'ANMF');
+	}
+
+	if (format === 'avif') {
+		return collectIsoBmffBrands(input).has(AVIF_SEQUENCE_BRAND);
+	}
+
+	if (format === 'png') {
+		return containsAscii(input, 'acTL');
+	}
+
+	return false;
+};
+
+export const mimeTypeForImageFormat = (format: ImageFormat) =>
+	format === 'jpeg' ? 'image/jpeg' : `image/${format}`;
+
+const toImageData = (image: RawImage) =>
+	new ImageData(new Uint8ClampedArray(image.data), image.width, image.height);
+
+const fromImageData = (imageData: {
+	data: Uint8ClampedArray;
+	height: number;
+	width: number;
+}): RawImage => ({
+	data: imageData.data,
+	height: imageData.height,
+	width: imageData.width
+});
+
+export const decodeImage = async (input: Uint8Array, format: ImageFormat): Promise<RawImage> => {
+	// slice() copies the view into a standalone ArrayBuffer (never shared).
+	const buffer = input.buffer.slice(
+		input.byteOffset,
+		input.byteOffset + input.byteLength
+	) as ArrayBuffer;
+
+	if (format === 'avif') {
+		await ensureAvifDecode();
+		const imageData = await decodeAvifImage(buffer);
+
+		if (!imageData) {
+			throw new Error('Failed to decode AVIF image');
+		}
+
+		return fromImageData(imageData);
+	}
+
+	if (format === 'webp') {
+		await ensureWebpDecode();
+
+		return fromImageData(await decodeWebpImage(buffer));
+	}
+
+	if (format === 'png') {
+		await ensurePngDecode();
+
+		return fromImageData(await decodePngImage(buffer));
+	}
+
+	await ensureJpegDecode();
+
+	return fromImageData(await decodeJpegImage(buffer));
+};
+
+const AVIF_CHROMA_SUBSAMPLING_VALUES = {
+	'4:2:0': 1,
+	'4:4:4': 3
+} as const;
+
+// Matches the previous sharp pipeline's `effort: 4` middle ground; jSquash
+// speed runs 0 (slowest) to 10 and defaults to 6.
+const AVIF_ENCODE_SPEED = 6;
+
+export const encodeAvif = async (
+	image: RawImage,
+	settings: AvifEncodeSettings
+): Promise<Uint8Array> => {
+	await ensureAvifEncode();
+
+	const encoded = await encodeAvifImage(toImageData(image), {
+		quality: settings.quality,
+		speed: AVIF_ENCODE_SPEED,
+		subsample: AVIF_CHROMA_SUBSAMPLING_VALUES[settings.chromaSubsampling]
+	});
+
+	return new Uint8Array(encoded);
+};
+
+export const encodePng = async (image: RawImage): Promise<Uint8Array> => {
+	await ensurePngEncode();
+
+	return new Uint8Array(await encodePngImage(toImageData(image)));
+};
+
+export const resizeImage = async (
+	image: RawImage,
+	target: { height: number; width: number }
+): Promise<RawImage> => {
+	if (image.width === target.width && image.height === target.height) {
+		return image;
+	}
+
+	await ensureResize();
+
+	return fromImageData(
+		await resizeImageData(toImageData(image), {
+			fitMethod: 'stretch',
+			height: target.height,
+			width: target.width
+		})
+	);
+};
+
+export const containOnBackground = async (
+	image: RawImage,
+	target: { background: RgbColor; height: number; width: number }
+): Promise<RawImage> => {
+	const scale = Math.min(target.width / image.width, target.height / image.height);
+	const scaledWidth = Math.max(1, Math.round(image.width * scale));
+	const scaledHeight = Math.max(1, Math.round(image.height * scale));
+	const scaled = await resizeImage(image, { height: scaledHeight, width: scaledWidth });
+	const canvas = createSolidImage(target.width, target.height, target.background);
+
+	blitWithAlpha(
+		canvas,
+		scaled,
+		Math.floor((target.width - scaledWidth) / 2),
+		Math.floor((target.height - scaledHeight) / 2)
+	);
+
+	return canvas;
+};
+
+export const coverResize = async (
+	image: RawImage,
+	target: { height: number; width: number }
+): Promise<RawImage> => {
+	const scale = Math.max(target.width / image.width, target.height / image.height);
+	const scaled = await resizeImage(image, {
+		height: Math.max(target.height, Math.round(image.height * scale)),
+		width: Math.max(target.width, Math.round(image.width * scale))
+	});
+
+	return cropCenter(scaled, target.width, target.height);
+};
+
+export const renderSvgToRaster = async (
+	svg: string,
+	target: { height: number; width: number }
+): Promise<RawImage> => {
+	await ensureResvg();
+
+	const renderer = new Resvg(svg, {
+		fitTo: { mode: 'width', value: target.width }
+	});
+	const rendered = renderer.render();
+	const image: RawImage = {
+		data: new Uint8ClampedArray(rendered.pixels),
+		height: rendered.height,
+		width: rendered.width
+	};
+
+	rendered.free();
+	renderer.free();
+
+	return resizeImage(image, target);
+};

--- a/apps/web/src/lib/server/media/codecs/loader.ts
+++ b/apps/web/src/lib/server/media/codecs/loader.ts
@@ -1,0 +1,41 @@
+// Cloudflare Workers disallow compiling WASM from bytes at runtime, so each codec
+// module must arrive as a WebAssembly.Module import bundled by wrangler. Node has
+// no native .wasm imports, so there we read the binary from node_modules instead.
+export const runningInCloudflareWorkers =
+	typeof caches !== 'undefined' &&
+	(caches as unknown as { default?: unknown }).default !== undefined;
+
+const loadNodeWasmModule = async (specifier: string): Promise<WebAssembly.Module> => {
+	const { createRequire } = await import('node:module');
+	const { readFile } = await import('node:fs/promises');
+	const require = createRequire(import.meta.url);
+
+	return WebAssembly.compile(await readFile(require.resolve(specifier)));
+};
+
+export const loadCodecWasmModule = async (
+	specifier: string,
+	importWorkersWasmModule: () => Promise<{ default: WebAssembly.Module }>
+): Promise<WebAssembly.Module> =>
+	runningInCloudflareWorkers
+		? (await importWorkersWasmModule()).default
+		: loadNodeWasmModule(specifier);
+
+class ImageDataPolyfill {
+	readonly colorSpace = 'srgb';
+	readonly data: Uint8ClampedArray;
+	readonly height: number;
+	readonly width: number;
+
+	constructor(data: Uint8ClampedArray, width: number, height?: number) {
+		this.data = data;
+		this.width = width;
+		this.height = height ?? data.byteLength / (width * 4);
+	}
+}
+
+export const ensureImageDataGlobal = () => {
+	if (typeof globalThis.ImageData === 'undefined') {
+		globalThis.ImageData = ImageDataPolyfill as unknown as typeof ImageData;
+	}
+};

--- a/apps/web/src/lib/server/media/codecs/raster.ts
+++ b/apps/web/src/lib/server/media/codecs/raster.ts
@@ -1,0 +1,126 @@
+export type RawImage = {
+	data: Uint8ClampedArray;
+	height: number;
+	width: number;
+};
+
+export type RgbColor = { b: number; g: number; r: number };
+
+export const parseHexColor = (color: string): RgbColor => {
+	const normalized = color.replace('#', '');
+	const expanded =
+		normalized.length === 3
+			? normalized
+					.split('')
+					.map((channel) => channel + channel)
+					.join('')
+			: normalized;
+
+	if (!/^[0-9a-fA-F]{6}$/.test(expanded)) {
+		throw new Error(`Unsupported background color: ${color}`);
+	}
+
+	return {
+		b: parseInt(expanded.slice(4, 6), 16),
+		g: parseInt(expanded.slice(2, 4), 16),
+		r: parseInt(expanded.slice(0, 2), 16)
+	};
+};
+
+export const createSolidImage = (width: number, height: number, color: RgbColor): RawImage => {
+	const data = new Uint8ClampedArray(width * height * 4);
+
+	for (let index = 0; index < data.length; index += 4) {
+		data[index] = color.r;
+		data[index + 1] = color.g;
+		data[index + 2] = color.b;
+		data[index + 3] = 255;
+	}
+
+	return { data, height, width };
+};
+
+export const flattenOntoBackground = (image: RawImage, color: RgbColor): RawImage => {
+	const data = new Uint8ClampedArray(image.data.length);
+
+	for (let index = 0; index < data.length; index += 4) {
+		const alpha = image.data[index + 3] / 255;
+		const inverse = 1 - alpha;
+
+		data[index] = image.data[index] * alpha + color.r * inverse;
+		data[index + 1] = image.data[index + 1] * alpha + color.g * inverse;
+		data[index + 2] = image.data[index + 2] * alpha + color.b * inverse;
+		data[index + 3] = 255;
+	}
+
+	return { data, height: image.height, width: image.width };
+};
+
+export const blitWithAlpha = (canvas: RawImage, image: RawImage, left: number, top: number) => {
+	for (let y = 0; y < image.height; y += 1) {
+		const targetY = top + y;
+
+		if (targetY < 0 || targetY >= canvas.height) {
+			continue;
+		}
+
+		for (let x = 0; x < image.width; x += 1) {
+			const targetX = left + x;
+
+			if (targetX < 0 || targetX >= canvas.width) {
+				continue;
+			}
+
+			const sourceIndex = (y * image.width + x) * 4;
+			const targetIndex = (targetY * canvas.width + targetX) * 4;
+			const alpha = image.data[sourceIndex + 3] / 255;
+			const inverse = 1 - alpha;
+
+			canvas.data[targetIndex] =
+				image.data[sourceIndex] * alpha + canvas.data[targetIndex] * inverse;
+			canvas.data[targetIndex + 1] =
+				image.data[sourceIndex + 1] * alpha + canvas.data[targetIndex + 1] * inverse;
+			canvas.data[targetIndex + 2] =
+				image.data[sourceIndex + 2] * alpha + canvas.data[targetIndex + 2] * inverse;
+			canvas.data[targetIndex + 3] = 255;
+		}
+	}
+};
+
+export const cropCenter = (image: RawImage, width: number, height: number): RawImage => {
+	const left = Math.max(0, Math.floor((image.width - width) / 2));
+	const top = Math.max(0, Math.floor((image.height - height) / 2));
+	const data = new Uint8ClampedArray(width * height * 4);
+
+	for (let y = 0; y < height; y += 1) {
+		const sourceStart = ((top + y) * image.width + left) * 4;
+
+		data.set(image.data.subarray(sourceStart, sourceStart + width * 4), y * width * 4);
+	}
+
+	return { data, height, width };
+};
+
+// Multiplies each pixel's alpha by the antialiased coverage of a rounded
+// rectangle spanning the full image, using the signed distance to its edge.
+export const applyRoundedRectAlpha = (image: RawImage, radius: number): RawImage => {
+	const data = new Uint8ClampedArray(image.data);
+	const halfWidth = image.width / 2;
+	const halfHeight = image.height / 2;
+
+	for (let y = 0; y < image.height; y += 1) {
+		for (let x = 0; x < image.width; x += 1) {
+			const distanceX = Math.abs(x + 0.5 - halfWidth) - (halfWidth - radius);
+			const distanceY = Math.abs(y + 0.5 - halfHeight) - (halfHeight - radius);
+			const outside = Math.hypot(Math.max(distanceX, 0), Math.max(distanceY, 0));
+			const inside = Math.min(Math.max(distanceX, distanceY), 0);
+			const distance = outside + inside - radius;
+			const coverage = Math.min(Math.max(0.5 - distance, 0), 1);
+			const index = (y * image.width + x) * 4;
+
+			data[index + 3] = image.data[index + 3] * coverage;
+		}
+	}
+
+	return { data, height: image.height, width: image.width };
+};

--- a/apps/web/src/lib/server/media/codecs/wasm-modules.d.ts
+++ b/apps/web/src/lib/server/media/codecs/wasm-modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.wasm' {
+	const wasmModule: WebAssembly.Module;
+	export default wasmModule;
+}

--- a/apps/web/src/lib/server/media/sanitization.ts
+++ b/apps/web/src/lib/server/media/sanitization.ts
@@ -1,4 +1,3 @@
-import sharp from 'sharp';
 import {
 	ARTWORK_MEDIA_CONTENT_TYPE,
 	ARTWORK_MEDIA_HEIGHT,
@@ -6,6 +5,20 @@ import {
 	ARTWORK_MEDIA_WIDTH
 } from '$lib/server/artwork/config';
 import { ArtworkFlowError } from '$lib/server/artwork/errors';
+import type { SanitizedMedia } from '$lib/server/artwork/types';
+import {
+	containOnBackground,
+	decodeImage,
+	encodeAvif,
+	hasAvifMagicBytes,
+	hasWebpMagicBytes,
+	isAnimatedImage,
+	mimeTypeForImageFormat,
+	parseHexColor,
+	sniffImageFormat,
+	type AvifEncodeSettings,
+	type RawImage
+} from '$lib/server/media/codecs';
 import {
 	AVATAR_MEDIA_CONTENT_TYPE,
 	AVATAR_MEDIA_HEIGHT,
@@ -13,7 +26,6 @@ import {
 	AVATAR_UPLOAD_CONTENT_TYPE,
 	AVATAR_MEDIA_WIDTH
 } from '$lib/server/user/config';
-import type { SanitizedMedia } from '$lib/server/artwork/types';
 
 type MediaSanitizationProfile = {
 	contentType: string;
@@ -26,18 +38,19 @@ type MediaSanitizationProfile = {
 	width: number;
 };
 
-const CANONICAL_AVIF_OPTIONS = {
+const CANONICAL_AVIF_OPTIONS: AvifEncodeSettings = {
 	chromaSubsampling: '4:4:4',
-	effort: 4,
 	quality: 100
-} as const;
+};
 
-const ARTWORK_CANONICAL_AVIF_ATTEMPTS = [
-	{ chromaSubsampling: '4:2:0', effort: 4, quality: 70 },
-	{ chromaSubsampling: '4:2:0', effort: 4, quality: 55 },
-	{ chromaSubsampling: '4:2:0', effort: 4, quality: 42 },
-	{ chromaSubsampling: '4:2:0', effort: 4, quality: 32 }
-] as const;
+const ARTWORK_CANONICAL_AVIF_ATTEMPTS: ReadonlyArray<AvifEncodeSettings> = [
+	{ chromaSubsampling: '4:2:0', quality: 70 },
+	{ chromaSubsampling: '4:2:0', quality: 55 },
+	{ chromaSubsampling: '4:2:0', quality: 42 },
+	{ chromaSubsampling: '4:2:0', quality: 32 }
+];
+
+const ARTWORK_CANVAS_BACKGROUND = parseHexColor('#fdfbf7');
 
 const ARTWORK_SOURCE_CONTENT_TYPES = new Set([
 	'image/avif',
@@ -96,91 +109,49 @@ const oversizedOutputError = (profile: MediaSanitizationProfile) =>
 		'MEDIA_TOO_LARGE'
 	);
 
-const ISO_BMFF_FTYP_OFFSET = 4;
-const ISO_BMFF_BRAND_OFFSET = 8;
-const ISO_BMFF_HEADER_BYTES = 16;
-const ISO_BMFF_BRAND_BYTES = 4;
-const AVIF_BRANDS = new Set(['avif', 'avis']);
-const WEBP_RIFF = 'RIFF';
-const WEBP_BRAND = 'WEBP';
+export { hasAvifMagicBytes, hasWebpMagicBytes };
 
-const readAscii = (input: Uint8Array, start: number, length: number) =>
-	String.fromCharCode(...input.subarray(start, start + length));
+const decodeStillImage = async (
+	inputBuffer: Uint8Array,
+	expectedContentType: string,
+	profile: MediaSanitizationProfile
+) => {
+	const format = sniffImageFormat(inputBuffer);
 
-const hasAvifMagicBytes = (input: Uint8Array) => {
-	if (input.byteLength < ISO_BMFF_HEADER_BYTES) {
-		return false;
+	if (!format || mimeTypeForImageFormat(format) !== expectedContentType) {
+		throw invalidContentError(profile);
 	}
 
-	if (readAscii(input, ISO_BMFF_FTYP_OFFSET, ISO_BMFF_BRAND_BYTES) !== 'ftyp') {
-		return false;
+	if (isAnimatedImage(inputBuffer, format)) {
+		throw invalidContentError(profile);
 	}
 
-	const majorBrand = readAscii(input, ISO_BMFF_BRAND_OFFSET, ISO_BMFF_BRAND_BYTES);
-	if (AVIF_BRANDS.has(majorBrand)) {
-		return true;
+	let image: RawImage;
+
+	try {
+		image = await decodeImage(inputBuffer, format);
+	} catch {
+		throw invalidContentError(profile);
 	}
 
-	for (
-		let offset = ISO_BMFF_HEADER_BYTES;
-		offset + ISO_BMFF_BRAND_BYTES <= input.byteLength;
-		offset += 4
-	) {
-		if (AVIF_BRANDS.has(readAscii(input, offset, ISO_BMFF_BRAND_BYTES))) {
-			return true;
-		}
+	if (!image.width || !image.height) {
+		throw invalidContentError(profile);
 	}
 
-	return false;
+	return image;
 };
 
-const hasWebpMagicBytes = (input: Uint8Array) => {
-	if (input.byteLength < 12) {
-		return false;
-	}
+const encodeCanonicalAvif = async (image: RawImage) => encodeAvif(image, CANONICAL_AVIF_OPTIONS);
 
-	return readAscii(input, 0, 4) === WEBP_RIFF && readAscii(input, 8, 4) === WEBP_BRAND;
-};
+const encodeCanonicalArtworkAvif = async (image: RawImage) => {
+	const contained = await containOnBackground(image, {
+		background: ARTWORK_CANVAS_BACKGROUND,
+		height: artworkProfile.height,
+		width: artworkProfile.width
+	});
 
-const expectedMimeTypeForMetadata = (metadata: sharp.Metadata) => {
-	if (metadata.format === 'jpeg') {
-		return 'image/jpeg';
-	}
-
-	if (metadata.format === 'png') {
-		return 'image/png';
-	}
-
-	if (metadata.format === 'webp') {
-		return 'image/webp';
-	}
-
-	if (metadata.format === 'heif' && metadata.compression === 'av1') {
-		return 'image/avif';
-	}
-
-	return null;
-};
-
-const isCanonicalAvif = (metadata: sharp.Metadata) =>
-	metadata.format === 'heif' && metadata.compression === 'av1';
-
-const hasExpectedDimensions = (metadata: sharp.Metadata, profile: MediaSanitizationProfile) =>
-	metadata.width === profile.width && metadata.height === profile.height;
-
-const encodeCanonicalAvif = async (inputBuffer: Uint8Array) =>
-	sharp(inputBuffer, { animated: false }).avif(CANONICAL_AVIF_OPTIONS).toBuffer();
-
-const encodeCanonicalArtworkAvif = async (inputBuffer: Uint8Array) => {
 	for (const avifOptions of ARTWORK_CANONICAL_AVIF_ATTEMPTS) {
-		const outputBuffer = await sharp(inputBuffer, { animated: false })
-			.resize(artworkProfile.width, artworkProfile.height, {
-				background: '#fdfbf7',
-				fit: 'contain'
-			})
-			.flatten({ background: '#fdfbf7' })
-			.avif(avifOptions)
-			.toBuffer();
+		const outputBuffer = await encodeAvif(contained, avifOptions);
 
 		if (outputBuffer.byteLength <= artworkProfile.maxBytes) {
 			return outputBuffer;
@@ -190,13 +161,25 @@ const encodeCanonicalArtworkAvif = async (inputBuffer: Uint8Array) => {
 	throw oversizedOutputError(artworkProfile);
 };
 
+const toSanitizedMedia = (
+	outputBuffer: Uint8Array,
+	profile: MediaSanitizationProfile
+): SanitizedMedia => ({
+	contentType: profile.contentType,
+	file: new File([Uint8Array.from(outputBuffer)], profile.outputFileName, {
+		type: profile.contentType
+	}),
+	height: profile.height,
+	sizeBytes: outputBuffer.byteLength,
+	width: profile.width
+});
+
 const sanitizeDecodedImageUpload = async (
 	file: File,
 	profile: MediaSanitizationProfile,
 	options: {
-		encodeOutput?: (inputBuffer: Uint8Array, profile: MediaSanitizationProfile) => Promise<Buffer>;
+		encodeOutput?: (image: RawImage, profile: MediaSanitizationProfile) => Promise<Uint8Array>;
 		expectInput: (inputBuffer: Uint8Array) => boolean;
-		isValidMetadata: (metadata: sharp.Metadata) => boolean;
 	}
 ): Promise<SanitizedMedia> => {
 	if (file.type !== profile.inputType) {
@@ -217,36 +200,18 @@ const sanitizeDecodedImageUpload = async (
 		throw invalidContentError(profile);
 	}
 
-	let metadata;
+	const image = await decodeStillImage(inputBuffer, file.type, profile);
 
-	try {
-		metadata = await sharp(inputBuffer, { animated: false }).metadata();
-	} catch {
-		throw invalidContentError(profile);
-	}
-
-	if (!options.isValidMetadata(metadata)) {
-		throw invalidContentError(profile);
-	}
-
-	if (!metadata.width || !metadata.height || (metadata.pages ?? 1) !== 1) {
-		throw invalidContentError(profile);
-	}
-
-	if (expectedMimeTypeForMetadata(metadata) !== file.type) {
-		throw invalidContentError(profile);
-	}
-
-	if (!hasExpectedDimensions(metadata, profile)) {
+	if (image.width !== profile.width || image.height !== profile.height) {
 		throw invalidDimensionsError(profile);
 	}
 
-	let outputBuffer: Buffer;
+	let outputBuffer: Uint8Array;
 
 	try {
 		outputBuffer = await (options.encodeOutput
-			? options.encodeOutput(inputBuffer, profile)
-			: encodeCanonicalAvif(inputBuffer));
+			? options.encodeOutput(image, profile)
+			: encodeCanonicalAvif(image));
 	} catch (error) {
 		if (error instanceof ArtworkFlowError) {
 			throw error;
@@ -259,28 +224,19 @@ const sanitizeDecodedImageUpload = async (
 		throw oversizedOutputError(profile);
 	}
 
-	return {
-		contentType: profile.contentType,
-		file: new File([Uint8Array.from(outputBuffer)], profile.outputFileName, {
-			type: profile.contentType
-		}),
-		height: profile.height,
-		sizeBytes: outputBuffer.byteLength,
-		width: profile.width
-	};
+	return toSanitizedMedia(outputBuffer, profile);
 };
 
 export const sanitizeAvifUpload = async (
 	file: File,
 	profile: MediaSanitizationProfile,
 	options?: {
-		encodeOutput?: (inputBuffer: Uint8Array, profile: MediaSanitizationProfile) => Promise<Buffer>;
+		encodeOutput?: (image: RawImage, profile: MediaSanitizationProfile) => Promise<Uint8Array>;
 	}
 ): Promise<SanitizedMedia> =>
 	sanitizeDecodedImageUpload(file, profile, {
 		encodeOutput: options?.encodeOutput,
-		expectInput: hasAvifMagicBytes,
-		isValidMetadata: isCanonicalAvif
+		expectInput: hasAvifMagicBytes
 	});
 
 export const sanitizeArtworkMedia = async (file: File) => {
@@ -303,27 +259,12 @@ export const sanitizeArtworkMedia = async (file: File) => {
 	}
 
 	const inputBuffer = new Uint8Array(await file.arrayBuffer());
+	const image = await decodeStillImage(inputBuffer, file.type, artworkProfile);
 
-	let metadata: sharp.Metadata;
-
-	try {
-		metadata = await sharp(inputBuffer, { animated: false }).metadata();
-	} catch {
-		throw invalidContentError(artworkProfile);
-	}
-
-	if (!metadata.width || !metadata.height || (metadata.pages ?? 1) !== 1) {
-		throw invalidContentError(artworkProfile);
-	}
-
-	if (expectedMimeTypeForMetadata(metadata) !== file.type) {
-		throw invalidContentError(artworkProfile);
-	}
-
-	let outputBuffer: Buffer;
+	let outputBuffer: Uint8Array;
 
 	try {
-		outputBuffer = await encodeCanonicalArtworkAvif(inputBuffer);
+		outputBuffer = await encodeCanonicalArtworkAvif(image);
 	} catch (error) {
 		if (error instanceof ArtworkFlowError) {
 			throw error;
@@ -332,19 +273,10 @@ export const sanitizeArtworkMedia = async (file: File) => {
 		throw invalidContentError(artworkProfile);
 	}
 
-	return {
-		contentType: artworkProfile.contentType,
-		file: new File([Uint8Array.from(outputBuffer)], artworkProfile.outputFileName, {
-			type: artworkProfile.contentType
-		}),
-		height: artworkProfile.height,
-		sizeBytes: outputBuffer.byteLength,
-		width: artworkProfile.width
-	};
+	return toSanitizedMedia(outputBuffer, artworkProfile);
 };
 
 export const sanitizeAvatarMedia = (file: File) =>
 	sanitizeDecodedImageUpload(file, avatarProfile, {
-		expectInput: hasWebpMagicBytes,
-		isValidMetadata: (metadata) => metadata.format === 'webp'
+		expectInput: hasWebpMagicBytes
 	});

--- a/apps/web/src/lib/server/user/favicon.ts
+++ b/apps/web/src/lib/server/user/favicon.ts
@@ -1,29 +1,29 @@
-import sharp from 'sharp';
+import {
+	applyRoundedRectAlpha,
+	coverResize,
+	cropCenter,
+	decodeImage,
+	encodePng,
+	sniffImageFormat
+} from '$lib/server/media/codecs';
 
 const FAVICON_SIZE = 64;
 const FAVICON_RADIUS = 18;
 const FAVICON_ZOOM_FACTOR = 1.22;
 
-const buildRoundedMaskSvg = (size: number, radius: number) =>
-	`
-<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
-	<rect width="${size}" height="${size}" rx="${radius}" ry="${radius}" fill="#ffffff" />
-</svg>`.trim();
-
 export const renderAvatarFaviconPng = async (input: Buffer | Uint8Array | ArrayBuffer) => {
-	const zoomedSize = Math.ceil(FAVICON_SIZE * FAVICON_ZOOM_FACTOR);
-	const overflow = Math.floor((zoomedSize - FAVICON_SIZE) / 2);
-	const roundedMask = Buffer.from(buildRoundedMaskSvg(FAVICON_SIZE, FAVICON_RADIUS));
+	const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+	const format = sniffImageFormat(bytes);
 
-	return sharp(input, { animated: false })
-		.resize(zoomedSize, zoomedSize, { fit: 'cover', position: 'centre' })
-		.extract({
-			height: FAVICON_SIZE,
-			left: overflow,
-			top: overflow,
-			width: FAVICON_SIZE
-		})
-		.composite([{ blend: 'dest-in', input: roundedMask }])
-		.png()
-		.toBuffer();
+	if (!format) {
+		throw new Error('Avatar media has an unsupported image format');
+	}
+
+	const zoomedSize = Math.ceil(FAVICON_SIZE * FAVICON_ZOOM_FACTOR);
+	const decoded = await decodeImage(bytes, format);
+	const zoomed = await coverResize(decoded, { height: zoomedSize, width: zoomedSize });
+	const cropped = cropCenter(zoomed, FAVICON_SIZE, FAVICON_SIZE);
+	const rounded = applyRoundedRectAlpha(cropped, FAVICON_RADIUS);
+
+	return encodePng(rounded);
 };

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-node';
+import adapter from '@sveltejs/adapter-cloudflare';
 import { relative, sep } from 'node:path';
 
 const routesDirectory = process.env.SVELTEKIT_ROUTES_DIR ?? 'src/routes';

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -23,6 +23,13 @@ const strokeJsonRuntimeRoot = resolve(workspaceRoot, 'packages/stroke-json-runti
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	build: {
+		rollupOptions: {
+			// .wasm imports stay external so wrangler bundles them as
+			// WebAssembly.Module entries (workerd forbids compiling from bytes).
+			external: (id) => id.endsWith('.wasm')
+		}
+	},
 	server: {
 		fs: {
 			allow: [workspaceRoot, strokeJsonRuntimeRoot]

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "not-the-louvre",
+	"main": ".svelte-kit/cloudflare/_worker.js",
+	"compatibility_date": "2026-06-01",
+	// nodejs_compat covers node:async_hooks (SvelteKit), node:crypto (better-auth)
+	// and the TCP sockets shim that postgres.js uses on Workers.
+	"compatibility_flags": ["nodejs_compat"],
+	"assets": {
+		"binding": "ASSETS",
+		"directory": ".svelte-kit/cloudflare"
+	},
+	"observability": {
+		"enabled": true
+	}
+	// AVIF encoding in WASM can take several seconds of CPU per upload. The
+	// Workers paid plan defaults to 30s CPU per request which is enough; on the
+	// free plan (10ms) media publishing will not work. Uncomment to raise:
+	// "limits": { "cpu_ms": 60000 }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,13 @@
       "version": "0.0.1",
       "dependencies": {
         "@2toad/profanity": "^3.3.0",
+        "@jsquash/avif": "^2.1.1",
+        "@jsquash/jpeg": "^1.6.0",
+        "@jsquash/png": "^3.1.1",
+        "@jsquash/resize": "^2.1.1",
+        "@jsquash/webp": "^1.5.0",
         "@not-the-louvre/stroke-json-runtime": "workspace:*",
+        "@resvg/resvg-wasm": "^2.6.2",
         "@supabase/supabase-js": "^2.100.1",
         "@threlte/core": "^8.5.2",
         "@threlte/extras": "^9.13.0",
@@ -21,7 +27,6 @@
         "jose": "^6.2.2",
         "lucide-svelte": "^1.0.1",
         "postgres": "^3.4.8",
-        "sharp": "^0.34.5",
         "three": "^0.183.2",
         "virtua": "^0.49.0",
         "zod": "^4.3.6",
@@ -32,6 +37,7 @@
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.58.2",
         "@sveltejs/adapter-auto": "^7.0.0",
+        "@sveltejs/adapter-cloudflare": "^7.2.8",
         "@sveltejs/adapter-node": "^5.3.2",
         "@sveltejs/kit": "^2.50.2",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -49,6 +55,7 @@
         "prettier": "^3.8.1",
         "prettier-plugin-svelte": "^3.4.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
+        "sharp": "^0.34.5",
         "svelte": "^5.54.0",
         "svelte-check": "^4.4.2",
         "tailwindcss": "^4.1.18",
@@ -57,6 +64,7 @@
         "vite": "^7.3.1",
         "vitest": "^4.1.0",
         "vitest-browser-svelte": "^2.0.2",
+        "wrangler": "^4.100.0",
       },
     },
     "packages/stroke-json-runtime": {
@@ -156,6 +164,24 @@
     "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
 
     "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
+
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260611.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260611.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260611.1", "", { "os": "linux", "cpu": "x64" }, "sha512-PfNjpxOlaIgZFYuhD7+neEEewCN2Ud993wEEN0fmbtSOax1AK53LGqmXUDvFhnbkHxJLFAxYCSNISW8QbzaAIg=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260611.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260611.1", "", { "os": "win32", "cpu": "x64" }, "sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260612.1", "", {}, "sha512-PMQI7XP/wrMhxyjseUHoHj6XFqkHaf4utWQ/hhefVY8oMK2LJ730oeQ7H/nZSVMexZe39DzsdOx7sf1PqMr7+Q=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
 
@@ -305,6 +331,16 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@jsquash/avif": ["@jsquash/avif@2.1.1", "", { "dependencies": { "wasm-feature-detect": "^1.2.11" } }, "sha512-LMRxd0fMgfCLtobDh0/sFYJMMiRJTNYSEEWvRDKXlAeZ08t3gI5V+1thIT0XjXJ+SVG7Zug9B0XPyx0Ti5VRNA=="],
+
+    "@jsquash/jpeg": ["@jsquash/jpeg@1.6.0", "", {}, "sha512-zwN46Awh1VM6gXlIcALwb5WzqK5H2e6+Awcs1QP8AvS8ohsK/sbE4esvmH4jhlhW7+CgiUUww66vg0aTnlSIMA=="],
+
+    "@jsquash/png": ["@jsquash/png@3.1.1", "", {}, "sha512-C10pc+0H6j0h8fENOfnGOvkXCmvpSQTDGlfGd0sHphZhPSGTyLjIrHba0FaZZdsKqA/wlmhYicUHb92vfZphaw=="],
+
+    "@jsquash/resize": ["@jsquash/resize@2.1.1", "", {}, "sha512-0R5UL1ZLHUT+carjVikcE1QfA+kfNQ2YamYyGVRmhfh4zttU5EY3bQBGxPIPtY2xIAw1P4Kgyxm2xrceRw1r2w=="],
+
+    "@jsquash/webp": ["@jsquash/webp@1.5.0", "", { "dependencies": { "wasm-feature-detect": "^1.2.11" } }, "sha512-KggLoj2MnRSfIqTeKe1EmbljTX2vuV7mh79k89PCL1pyqiDULcPM1L47twxXt0hkb68F70bXiL31MxsuoZtKFw=="],
+
     "@mrleebo/prisma-ast": ["@mrleebo/prisma-ast@0.13.1", "", { "dependencies": { "chevrotain": "^10.5.0", "lilconfig": "^2.1.0" } }, "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
@@ -319,7 +355,15 @@
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
     "@prisma/client": ["@prisma/client@5.22.0", "", { "peerDependencies": { "prisma": "*" }, "optionalPeers": ["prisma"] }, "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA=="],
+
+    "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.6.2", "", {}, "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw=="],
 
     "@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@29.0.2", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-S/ggWH1LU7jTyi9DxZOKyxpVd4hF/OZ0JrEbeLjXk/DFXwRny0tjD2c992zOUYQobLrVkRVMDdmHP16HKP7GRg=="],
 
@@ -379,6 +423,10 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w=="],
 
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.16", "", {}, "sha512-yNm/fYEcnpRjYduLMaddTK9XKYil6xB88+qFg79ZdZhHu1PadfoQmFW7pVTx7FZqMBNcUuThiAhxhENgtAO2/w=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@supabase/auth-js": ["@supabase/auth-js@2.100.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q=="],
@@ -398,6 +446,8 @@
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.9", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA=="],
 
     "@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@7.0.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ=="],
+
+    "@sveltejs/adapter-cloudflare": ["@sveltejs/adapter-cloudflare@7.2.8", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250507.0", "worktop": "0.8.0-next.18" }, "peerDependencies": { "@sveltejs/kit": "^2.0.0", "wrangler": "^4.0.0" } }, "sha512-bIdhY/Fi4AQmqiBdQVKnafH1h9Gw+xbCvHyUu4EouC8rJOU02zwhi14k/FDhQ0mJF1iblIu3m8UNQ8GpGIvIOQ=="],
 
     "@sveltejs/adapter-node": ["@sveltejs/adapter-node@5.5.4", "", { "dependencies": { "@rollup/plugin-commonjs": "^29.0.0", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.0", "rollup": "^4.59.0" }, "peerDependencies": { "@sveltejs/kit": "^2.4.0" } }, "sha512-45X92CXW+2J8ZUzPv3eLlKWEzINKiiGeFWTjyER4ZN4sGgNoaoeSkCY/QYNxHpPXy71QPsctwccBo9jJs0ySPQ=="],
 
@@ -545,6 +595,8 @@
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
@@ -630,6 +682,8 @@
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
@@ -817,6 +871,8 @@
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
+    "miniflare": ["miniflare@4.20260611.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.24.8", "workerd": "1.20260611.1", "ws": "8.20.1", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg=="],
+
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -866,6 +922,8 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -945,6 +1003,8 @@
 
     "regexp-to-ast": ["regexp-to-ast@0.5.0", "", {}, "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="],
 
+    "regexparam": ["regexparam@3.0.0", "", {}, "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
@@ -996,6 +1056,8 @@
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
@@ -1055,7 +1117,11 @@
 
     "typescript-eslint": ["typescript-eslint@8.57.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.2", "@typescript-eslint/parser": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2", "@typescript-eslint/utils": "8.57.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A=="],
 
+    "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
+
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -1073,6 +1139,8 @@
 
     "vitest-browser-svelte": ["vitest-browser-svelte@2.1.0", "", { "dependencies": { "@playwright/test": "^1.58.2", "@testing-library/svelte-core": "^1.0.0" }, "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0", "vitest": "^4.0.0" } }, "sha512-Uqcqn9gKhYoNOn5uGOQHSPIEGHgIz25zPP6R63LQ5+yEVHfDXdOKBMba9pBlPIgp31AxYbV9h43j9+W+5M5y+A=="],
 
+    "wasm-feature-detect": ["wasm-feature-detect@1.8.0", "", {}, "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ=="],
+
     "webgl-sdf-generator": ["webgl-sdf-generator@1.1.1", "", {}, "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -1080,6 +1148,12 @@
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "workerd": ["workerd@1.20260611.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260611.1", "@cloudflare/workerd-darwin-arm64": "1.20260611.1", "@cloudflare/workerd-linux-64": "1.20260611.1", "@cloudflare/workerd-linux-arm64": "1.20260611.1", "@cloudflare/workerd-windows-64": "1.20260611.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w=="],
+
+    "worktop": ["worktop@0.8.0-next.18", "", { "dependencies": { "mrmime": "^2.0.0", "regexparam": "^3.0.0" } }, "sha512-+TvsA6VAVoMC3XDKR5MoC/qlLqDixEfOBysDEKnPIPou/NvoPWCAuXHXMsswwlvmEuvX56lQjvELLyLuzTKvRw=="],
+
+    "wrangler": ["wrangler@4.100.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260611.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260611.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260611.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -1099,6 +1173,10 @@
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -1112,6 +1190,8 @@
     "@better-auth/cli/better-auth": ["better-auth@1.4.21", "", { "dependencies": { "@better-auth/core": "1.4.21", "@better-auth/telemetry": "1.4.21", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "better-call": "1.1.8", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.3.5" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-qdrIZS7xnGF2HPBV5wYNPWTkPojhauOOjz1+MhLvwFy+zXpgLofQmWsI5I9DY+ef845NKt93XcgpyAc4RPPT9A=="],
 
     "@better-auth/cli/drizzle-orm": ["drizzle-orm@0.41.0", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-7A4ZxhHk9gdlXmTdPj/lREtP+3u8KvZ4yEN6MYVxBzZGex5Wtdc+CWSbu7btgF6TB0N+MNPrvW7RKBbxJchs/Q=="],
+
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
@@ -1145,6 +1225,8 @@
 
     "eslint-plugin-svelte/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
 
+    "miniflare/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
     "nypm/citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
@@ -1164,6 +1246,12 @@
     "vite/esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "wrangler/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -1314,5 +1402,57 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+
+    "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
   }
 }

--- a/docs/deploy-cloudflare-workers.md
+++ b/docs/deploy-cloudflare-workers.md
@@ -1,0 +1,78 @@
+# Deploying to Cloudflare Workers
+
+The web app (`apps/web`) deploys to **Cloudflare Workers with static assets** via
+`@sveltejs/adapter-cloudflare`. CI deploys automatically on every push to `main`
+(`.github/workflows/deploy.yml`).
+
+## Why Workers and not Pages
+
+Cloudflare now recommends Workers (static assets) over Pages for new SvelteKit
+projects, and the same adapter targets both. The app relies on WebAssembly in two
+places, both of which run on `workerd`:
+
+- **stroke-json runtime** — the Rust-built drawing-document WASM
+  (`packages/stroke-json-runtime`).
+- **Image pipeline** — `sharp` was replaced with WASM codecs (`@jsquash/*` for
+  AVIF/WebP/PNG/JPEG decode-encode and resize, `@resvg/resvg-wasm` for
+  SVG→raster), because `sharp` is a native Node addon that cannot run on Workers.
+
+`workerd` forbids compiling WASM from bytes at runtime, so every `.wasm` import is
+kept external in the Vite build (`build.rollupOptions.external`) and bundled by
+Wrangler as a `WebAssembly.Module`. In Node (tests, `vite preview`) the same code
+reads the bytes from disk instead. The branch is chosen at runtime by detecting
+`caches.default`.
+
+## One-time Cloudflare setup
+
+1. Create the Worker (the first `wrangler deploy` does this) — its name is
+   `not-the-louvre` in `apps/web/wrangler.jsonc`.
+2. Set runtime secrets (NOT committed; these are read via `$env/dynamic/private`):
+
+   ```sh
+   cd apps/web
+   wrangler secret put DATABASE_URL
+   wrangler secret put BETTER_AUTH_SECRET
+   wrangler secret put SUPABASE_PUBLIC_URL
+   wrangler secret put SUPABASE_SECRET_KEY
+   wrangler secret put SERVICE_ROLE_KEY
+   wrangler secret put ARTWORK_STORAGE_BUCKET   # e.g. "artworks"
+   wrangler secret put ORIGIN                   # public https origin of the deployment
+   ```
+
+   (Match the keys in `apps/web/.env.example`. `JWT_SECRET`/`SUPABASE_JWT_SECRET`
+   too if your auth config reads it.)
+
+3. **Database connectivity**: the Worker connects to Postgres over TCP using
+   `postgres.js` + the `nodejs_compat` flag (already set in `wrangler.jsonc`).
+   Each request opens and closes its own connection because Workers cannot share
+   a socket across requests (see `runWithRequestDbConnection` in
+   `src/lib/server/db/index.ts`). For production throughput, front the database
+   with **Cloudflare Hyperdrive** and point `DATABASE_URL` at the Hyperdrive
+   connection string to get pooling and reduced latency.
+
+4. **CPU limits**: AVIF encoding in WASM costs seconds of CPU per upload. This
+   needs the Workers **paid** plan (the free plan caps at 10 ms). Raise the limit
+   in `wrangler.jsonc` via `limits.cpu_ms` if uploads time out.
+
+## GitHub Actions secrets
+
+Set these on the repository (Settings → Secrets and variables → Actions), ideally
+scoped to a `production` environment:
+
+| Secret                  | What it is                                                        |
+| ----------------------- | ----------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | API token with the **Edit Cloudflare Workers** template permissions |
+| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID                                        |
+
+The deploy job needs neither Rust nor a database: the stroke-json WASM is
+committed under `packages/stroke-json-runtime/generated`, and the SvelteKit build
+reads runtime env lazily (`$env/dynamic/private`), so it builds without secrets.
+
+## Local preview against the Worker runtime
+
+```sh
+cd apps/web
+# Put real values in .dev.vars (gitignored) — same keys as the secrets above.
+bun run build           # from repo root: `bun run build`
+bunx wrangler dev       # serves the worker on http://localhost:8787
+```

--- a/packages/stroke-json-runtime/package.json
+++ b/packages/stroke-json-runtime/package.json
@@ -8,6 +8,7 @@
 		".": "./src/index.ts",
 		"./browser": "./src/browser.ts",
 		"./server": "./src/server.ts",
+		"./server.wasm": "./generated/wasm/server/stroke_json_wasm_bg.wasm",
 		"./worker": "./src/worker.ts"
 	}
 }

--- a/packages/stroke-json-runtime/src/server.ts
+++ b/packages/stroke-json-runtime/src/server.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'node:fs/promises';
 import initStrokeJsonServerWasm, {
 	compact_document_losslessly_with_report,
 	decode_canonical_document,
@@ -31,14 +30,34 @@ import {
 	toStrokeJsonRuntimeError
 } from './internal';
 
-const loadDefaultServerBindings = async (): Promise<StrokeJsonBindings> => {
+// Cloudflare Workers forbid compiling WASM from bytes at runtime, so there the
+// binary must arrive as a WebAssembly.Module import resolved by the bundler.
+const runningInCloudflareWorkers =
+	typeof caches !== 'undefined' &&
+	(caches as unknown as { default?: unknown }).default !== undefined;
+
+const loadServerWasmModule = async (): Promise<WebAssembly.Module | Uint8Array> => {
+	if (runningInCloudflareWorkers) {
+		const { default: wasmModule } = (await import(
+			'@not-the-louvre/stroke-json-runtime/server.wasm'
+		)) as unknown as { default: WebAssembly.Module };
+
+		return wasmModule;
+	}
+
+	const { readFile } = await import('node:fs/promises');
 	const wasmUrl = new URL('../generated/wasm/server/stroke_json_wasm_bg.wasm', import.meta.url);
-	const wasmBytes = new Uint8Array(await readFile(wasmUrl));
+
+	return new Uint8Array(await readFile(wasmUrl));
+};
+
+const loadDefaultServerBindings = async (): Promise<StrokeJsonBindings> => {
+	const wasmModule = await loadServerWasmModule();
 
 	if (typeof initSync === 'function') {
-		initSync({ module: wasmBytes });
+		initSync({ module: wasmModule });
 	} else {
-		await initStrokeJsonServerWasm({ module_or_path: wasmBytes });
+		await initStrokeJsonServerWasm({ module_or_path: wasmModule });
 	}
 
 	return {

--- a/packages/stroke-json-runtime/src/wasm-modules.d.ts
+++ b/packages/stroke-json-runtime/src/wasm-modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.wasm' {
+	const wasmModule: WebAssembly.Module;
+	export default wasmModule;
+}


### PR DESCRIPTION
## What changes

Switches the production SvelteKit adapter from `@sveltejs/adapter-node` to `@sveltejs/adapter-cloudflare`, adds Wrangler configuration, and replaces runtime dependencies that cannot run on the Workers runtime:

- Adds Cloudflare adapter, Wrangler CLI, and WASM codec dependencies (`@jsquash/*`, `@resvg/resvg-wasm`).
- Loads the stroke-json runtime WASM as a module import so Wrangler bundles it for `workerd`.
- Replaces `sharp` with a WASM-based image codec pipeline for artwork, avatar, and favicon processing.
- Scopes Postgres connections per request using `AsyncLocalStorage` because Workers cannot share TCP sockets across requests.
- Updates production build and validation scripts for the Cloudflare output layout.
- Adds a GitHub Actions deploy workflow and deployment documentation.

## Why

To make the web app deployable on Cloudflare Workers with static assets, replacing the previous Node/VPS target.

## Testing

- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run check`
- [ ] `bun run test`
- [ ] Not run intentionally (explain why):

## Notes for review

- The full test suite (`bun run test`) was not run locally because it includes integration tests that require a running database and other runtime secrets. CI will run the suite on the PR.
- AVIF encoding in WASM is CPU-intensive; the deployment guide notes that the Workers paid plan is required for media uploads to work.